### PR TITLE
Prevent celery of restoring crontab to 1 hour when deploying to production

### DIFF
--- a/CodeListLibrary_project/cll/celery.py
+++ b/CodeListLibrary_project/cll/celery.py
@@ -5,6 +5,8 @@ from celery import Celery
 from celery.schedules import crontab
 from django.conf import settings
 
+from cll.settings import IS_DEVELOPMENT_PC
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cll.settings')
 app = Celery('cll')
 app.config_from_object('django.conf:settings', namespace='CELERY')
@@ -13,11 +15,11 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.conf.beat_schedule = {
     'send_mail': {
         'task': 'clinicalcode.tasks.send_scheduled_email',
-        'schedule': crontab(minute=58)
+        'schedule': crontab(minute=58) if IS_DEVELOPMENT_PC else crontab(minute=58,hour=12)
     },
     'send_message_test': {
         'task': 'clinicalcode.tasks.send_message_test',
-        'schedule': crontab(minute=58)
+        'schedule': crontab(minute=1) if IS_DEVELOPMENT_PC else crontab(minute=58,hour=12)
     }
 
 }


### PR DESCRIPTION
This commit just the tweak to the existing celery config. Sometimes when some changes are made to the production/demo website celery beat config restores the default crontab which is 58 minutes. But this commit will put different time which is every 12 hours of 58 minutes