### PR TITLE
Changes to tag_collection_ids filter

### DIFF
--- a/CodeListLibrary_project/cll/templates/clinicalcode/concept/index-cards.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/concept/index-cards.html
@@ -36,7 +36,7 @@
 								<li class="checkbox"  {% if not request.CURRENT_BRAND|length %} title="{{ tag.collection_brand }}" {% endif %}>
 									<label>
 									<input class="form-check-input filter_option collection" type="checkbox" name="collection_id" value="{{ tag.id }}" 
-									{% if tag.id in tag_ids_list  %} checked {% endif %}  
+									{% if tag.id in collection_ids_list  %} checked {% endif %}  
 									>
 									<span class="form-check-label">
 										{{ tag.description }}

--- a/CodeListLibrary_project/cll/templates/clinicalcode/concept/index.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/concept/index.html
@@ -21,7 +21,8 @@
 					 <div class="form-input-flex-container">
 						 <!-- Basic form queries -->
 						 <input type="text" placeholder="Search Concepts" name="search" id="search1" value="{{ search|default_if_none:'' }}">
-						 <input type="hidden" name="tag_collection_ids" id="tag_collection_ids" value="{{ tag_ids|default_if_none:'' }}">
+						 <input type="hidden" name="tag_ids" id="tag_ids"  value="{{ tag_ids|default_if_none:'' }}">
+						 <input type="hidden" name="collection_ids" id="collection_ids"  value="{{ collection_ids|default_if_none:'' }}">
 						 <input type="hidden" name="codingids" id="codingids"  value="{{ codingids|default_if_none:'' }}">
 						 <input type="hidden" name="page" id="page"  value="{{ page|default_if_none:1 }}">
 						 <input type="hidden" name="search_form" id="collection_search_form1"  class="collection_search_form"  value="{{ search_form }}">
@@ -193,7 +194,8 @@
 			'search': "{{ search }}",
 			'author': "{{ author }}",
 			'owner': "{{ owner }}",
-			'tag_collection_ids': "{{ tag_ids }}",
+			'tag_ids': "{{ tag_ids }}",
+			'collection_ids': "{{ collection_ids }}",
 			'codingids': "{{ coding_ids }}",
 			'startdate': "{{ filter_start_date }}",
 			'enddate': "{{ filter_end_date }}",

--- a/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/index-cards.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/index-cards.html
@@ -75,7 +75,7 @@
 								<li class="checkbox"  {% if not request.CURRENT_BRAND|length %} title="{{ tag.collection_brand }}" {% endif %}>
 									<label>
 									<input class="form-check-input filter_option collection" type="checkbox" name="collection_id" value="{{ tag.id }}" 
-									{% if tag.id in tag_ids_list  %} checked {% endif %}  
+									{% if tag.id in collection_ids_list  %} checked {% endif %}  
 									>
 									<span class="form-check-label">
 										{{ tag.description }}

--- a/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/index.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/index.html
@@ -21,7 +21,8 @@
 						<div class="form-input-flex-container">
 							<!-- Basic form queries -->
 							<input type="text" placeholder="Search Phenotypes" name="search" id="search1" value="{{ search|default_if_none:'' }}">
-							<input type="hidden" name="tag_collection_ids" id="tag_collection_ids"  value="{{ tag_ids|default_if_none:'' }}">
+							<input type="hidden" name="tag_ids" id="tag_ids"  value="{{ tag_ids|default_if_none:'' }}">
+							<input type="hidden" name="collection_ids" id="collection_ids"  value="{{ collection_ids|default_if_none:'' }}">
 							<input type="hidden" name="data_source_ids" id="data_source_ids"  value="{{ data_source_ids|default_if_none:'' }}">
 							<input type="hidden" name="selected_phenotype_types" id="selected_phenotype_types"  value="{{ selected_phenotype_types_str|default_if_none:'' }}">
 							<input type="hidden" name="search_form" id="collection_search_form1"  class="collection_search_form"  value="{{ search_form }}"> 
@@ -205,7 +206,8 @@
 			'author': "{{ author }}",
 			'owner': "{{ owner }}",
 			'data_source_ids': "{{ data_source_ids }}",
-			'tag_collection_ids': "{{ tag_ids }}",
+			'tag_ids': "{{ tag_ids }}",
+			'collection_ids': "{{ collection_ids }}",
 			'codingids': "{{ coding_ids }}",
 			'startdate': "{{ filter_start_date }}",
 			'enddate': "{{ filter_end_date }}",

--- a/CodeListLibrary_project/cll/templates/rest_framework/API-root-pg.html
+++ b/CodeListLibrary_project/cll/templates/rest_framework/API-root-pg.html
@@ -62,10 +62,13 @@
                   <li><code>?search=Alcohol</code><br>
                   search by part of concept name (do not put wild characters here)</li>
                   <li><code>?tag_collection_ids=11,4</code><br>
-                  You can specify tag or collection ids <br>
+                  You can specify tag and collection ids <br>
 	               (get tags from <code><a href="{{ tags }}" target="_blank" class="alert-link">{{ tags }}</a></code>)
 	               (get collections from <code><a href="{{ collections }}" target="_blank" class="alert-link">{{ collections }}</a></code>)
-	               </li>
+	                </li>
+								  <li><code>?collection_ids=18&tag_ids=1</code><br>
+									Or you can query tags and/or collections individually
+								  </li> 
                   <li><code>?show_only_validated_concepts=1</code><br>
                   will show only validated concepts</li>
                   <li><code>?brand=HDRUK</code><br>
@@ -332,10 +335,13 @@
 		              <li><code>?search=Alcohol</code><br>
 		              search by part of phenotype name (do not put wild characters here)</li>
 		              <li><code>?tag_collection_ids=11,4</code><br>
-		              You can specify tag or collection ids <br>
+		              You can specify tag and collection ids <br>
 		               (get tags from <code><a href="{{ tags }}" target="_blank" class="alert-link">{{ tags }}</a></code>)
 		               (get collections from <code><a href="{{ collections }}" target="_blank" class="alert-link">{{ collections }}</a></code>)
 		              </li>
+								  <li><code>?collection_ids=18&tag_ids=1</code><br>
+									Or you can query tags and/or collections individually
+								  </li> 
 		              <li><code>?selected_phenotype_types=drug,lifestyle risk factor</code><br>
 		              Specify types of the phenotypes<br>
                       You can get all available types from the <code><a href="{% url 'reference_data' %}" target="_blank" class="alert-link">reference data page</a></code>


### PR DESCRIPTION
R.E. #842 

1. [x] Split tag_collection_ids to tag_ids & collection_ids in Pheno/Concept views
2. [x] API allows tag_ids & collection_ids parameter
3. [x] API also allows tag_collection_ids for backwards compatability with current scripts until data / model changes are implemented
4. [x] Generalise the filter method in the backend to be reused across API & Views
5. [x] Update the API view to reflect new changes