### PR TITLE
Improvements to frontend

### DIFF
--- a/CodeListLibrary_project/clinicalcode/db_utils.py
+++ b/CodeListLibrary_project/clinicalcode/db_utils.py
@@ -84,7 +84,7 @@ def try_parse_phenotype_gender(gender):
             1. Array [string, string] e.g. ['Female', 'Male']
     
     """
-    gender = gender.split()
+    gender = '/'.join(gender.split(',')).split('/')
     gender = [''.join(e for e in x.lower() if e.isalpha()).capitalize() for x in gender]
     return gender
 

--- a/CodeListLibrary_project/clinicalcode/views/Concept.py
+++ b/CodeListLibrary_project/clinicalcode/views/Concept.py
@@ -211,8 +211,13 @@ def ConceptDetail_combined(request, pk, concept_history_id=None):
 
     tags = Tag.objects.filter(pk=-1)
     concept_tags = concept['tags']
+    has_collections = False
+    has_tags = False
     if concept_tags:
         tags = Tag.objects.filter(pk__in=concept_tags)
+
+        has_tags = tags.filter(tag_type=1).count() != 0
+        has_collections = tags.filter(tag_type=2).count() != 0
 
     #     tags =  Tag.objects.filter(pk=-1)
     #     tags_comp = db_utils.getHistoryTags(pk, concept_history_date)
@@ -315,6 +320,8 @@ def ConceptDetail_combined(request, pk, concept_history_id=None):
         'concept': concept,
         'components': components,
         'tags': tags,
+        'has_tags': has_tags,
+        'has_collections': has_collections,
         'user_can_edit': can_edit,
         'allowed_to_create': user_allowed_to_create,
         'user_can_export': user_can_export,

--- a/CodeListLibrary_project/clinicalcode/views/Phenotype.py
+++ b/CodeListLibrary_project/clinicalcode/views/Phenotype.py
@@ -392,13 +392,22 @@ def PhenotypeDetail_combined(request, pk, phenotype_history_id=None):
 
     tags = Tag.objects.filter(pk=-1)
     phenotype_tags = phenotype['tags']
+
+    has_tags = False
+    has_collections = False
     if phenotype_tags:
         tags = Tag.objects.filter(pk__in=phenotype_tags)
+
+        has_tags = tags.filter(tag_type=1).count() != 0
+        has_collections = tags.filter(tag_type=2).count() != 0
 
     data_sources = DataSource.objects.filter(pk=-1)
     phenotype_data_sources = phenotype['data_sources']  
     if phenotype_data_sources:
         data_sources = DataSource.objects.filter(pk__in=phenotype_data_sources)
+
+    # ------------------------- parse sex ----------------------------------
+    phenotype_gender = db_utils.try_parse_phenotype_gender(phenotype['sex'])
 
     # ----------------------------------------------------------------------
     concept_id_list = []
@@ -529,6 +538,9 @@ def PhenotypeDetail_combined(request, pk, phenotype_history_id=None):
         'phenotype': phenotype,
         'concept_informations': json.dumps(phenotype['concept_informations']),
         'tags': tags,
+        'gender': phenotype_gender,
+        'has_tags': has_tags,
+        'has_collections': has_collections,
         'data_sources': data_sources,
         'clinicalTerminologies': clinicalTerminologies,
         'user_can_edit': False,  # for now  #can_edit,

--- a/CodeListLibrary_project/clinicalcode/views/PhenotypeWorkingSet.py
+++ b/CodeListLibrary_project/clinicalcode/views/PhenotypeWorkingSet.py
@@ -227,6 +227,7 @@ def workingset_list(request):
         group_list = list(current_brand.values_list('groups', flat=True))
         filter_cond += " AND group_id IN(" + ', '.join(map(str, group_list)) + ") "
 
+    order_param = db_utils.get_order_from_parameter(des_order)
     workingset_srch = db_utils.get_visible_live_or_published_phenotype_workingset_versions(request,
                                                                             get_live_and_or_published_ver=get_live_and_or_published_ver,
                                                                             search=[search, ''][search_by_id],
@@ -236,7 +237,8 @@ def workingset_list(request):
                                                                             approved_status=approved_status,
                                                                             show_top_version_only=show_top_version_only,
                                                                             search_name_only = False,
-                                                                            highlight_result = True
+                                                                            highlight_result = True,
+                                                                            order_by=order_param
                                                                             )
     # create pagination
     paginator = Paginator(workingset_srch,

--- a/CodeListLibrary_project/cll/static/css/main.css
+++ b/CodeListLibrary_project/cll/static/css/main.css
@@ -1312,3 +1312,73 @@ code.api-codeblock .code-text-highlight, .code-comment-highlight {
 .ws-trash {
   margin-right: 10px;
 }
+
+
+/* Modifiers */
+.card-coding-block {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  background-color: #CCDAE1;
+  padding: 2px;
+  border-radius: 0.25rem;
+}
+
+.card-coding-item {
+  margin: 0 0.5rem 0 0;
+}
+
+.phenotype-type-badge {
+  background-color: #f9f2f4;
+  border-radius: 0.25rem;
+}
+
+.card-date-badge {
+  background-color: #BED8D4;
+  border-radius: 0.25rem;
+}
+
+.card-date-block {
+  display: inline-flex;
+  margin: 0 5px 0 0;
+}
+
+.card-noweight {
+  font-weight: normal;
+}
+
+.card-tag-sizing {
+  padding: 5px;
+  line-height: 1;
+  display: inline-block;
+  margin: 0;
+}
+
+.card-edit-sizing {
+  padding: 5px 10px 5px 10px ;
+  line-height: 1;
+  display: inline-block;
+  margin: 0;
+}
+
+.card-no-data {
+  color:rgba(109, 109, 109, 0.5);
+}
+
+.justified-label {
+  display: inline-flex;
+  min-width: 18rem;
+  justify-content: space-between;
+}
+
+.small-divider {
+  margin: 5px 0 5px 0;
+}
+
+.gender-badge-Male {
+  background-color:#E2F0CB
+}
+
+.gender-badge-Female {
+  background-color: #FFB7B2
+}

--- a/CodeListLibrary_project/cll/templates/clinicalcode/concept/concept_results.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/concept/concept_results.html
@@ -10,9 +10,9 @@
 	{% for concept in page_obj.object_list %}  
 			<div class="cl-card {% if concept.is_deleted is True %} cl-card-deleted {% endif %} {% cycle ' dark-div ' '' %}   ">
 				<div class="row form-group">
-					<div {% if concept.is_deleted is not True and concept.can_edit %} class="col-sm-10" {% else %}  class="col-sm-12" {% endif %} >
+					<div class="col-sm-8"> <!-- {% if concept.is_deleted is not True and concept.can_edit %} class="col-sm-10" {% else %}  class="col-sm-12" {% endif %} > -->
 						{% if user.is_authenticated and concept.is_published != 1 %}
-							<a class="" href="{% url 'concept_detail' concept.id %}">
+							<a class="" href="{% url 'concept_detail' concept.id %}"/>
 						{% else %}
 							<a class="" href="{% url 'concept_history_detail' concept.id concept.history_id %}">
 						{% endif %}
@@ -20,59 +20,52 @@
 							</a>
 				
 					</div>
-				{% if concept.is_deleted is not True and concept.can_edit %}
-					<div class="col-sm-2 text-right">					
-							<span>&nbsp;&nbsp;</span>
-							<a  class="btn btn-outline-primary btn-cl btn-cl-secondary" href="{% url 'concept_update' concept.id %}" title="Edit concept">
-								Edit
-							</a> 						
+					<div class="col-sm-4 text-right">
+						<span class="badge card-date-badge">
+							{% if user.is_authenticated %}
+								<span class="card-date-block">Modified:</span><i class="card-noweight">{{ concept.modified|date:"Y-m-d" }}</i>
+							{% else %}	
+								<span class="card-date-block">Published:</span><i class="card-noweight">{{ concept.publish_date|date:"Y-m-d" }}</i>
+							{% endif %}
+						</span>
 					</div>
-				{% endif %}					
 				</div>
 				
 				<div class="row form-group">
 					<div class="col-sm-12">
-<!-- 						<span {%if concept.author|length > 120 %}title="{{ concept.author }}" {% endif %} >{{ concept.author|truncatechars:120 }}</span> -->
 						{{ concept.author_highlighted|safe  }} 
 					</div>
 				</div>				
-				
 				<div class="row form-group">
-					<div class="col-sm-2">
+					<div class="col-sm-6 text-justify">
 						<!-- CodingSystems -->
 				   		<span class="badge">{{ concept.coding_system_name }}</span>
 					</div>
-					<div class="col-sm-10">
-						{% if user.is_authenticated %}
-							<i>{{ concept.modified|date:"Y-m-d" }}</i>
-						{% else %}	
-							<i>{{ concept.publish_date|date:"Y-m-d" }}</i>
-						{% endif %}	
-					</div>		
-<!-- 					<div class="col-sm-4 text-right"> -->
-<!-- 						{% if user.is_authenticated and concept.is_published == 1 %} -->
-<!--  							<span title="{{ concept.published }} on {{ concept.publish_date|date:"Y-m-d" }}" style="text-align: right;" ><i class="fa fa-paper-plane" aria-hidden="true"></i></span> --> 
-<!-- 						{% endif %}	 -->
-<!-- 					</div>	 -->
-				</div>				
-
-			{% if concept.tags %}
-				<div class="row form-group">
-					<div class="col-sm-12">
+					{% if concept.tags %}
+					<div class="col-sm-6 text-right">
 						<!-- tags -->
 						{% for tag in allTags %}
 							{% for tag_id in concept.tags %}
 								{% if tag.id == tag_id %}
-							   		<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
-							   	{% endif %}
+										<span class="tag label label-{{ tag.get_display_display }} card-tag-sizing">#{{ tag.description }}</span>
+									{% endif %}
 							{% endfor %}						
 						{% endfor %}			
+					</div>	
+					{% endif %}
+				</div>				
 
-					</div>
-				</div>
-			{% endif %}
-			  	
-	</div>				  
+			{% if concept.is_deleted is not True and concept.can_edit %}
+			<hr/>
+			<div class="row form-group">
+					<div class="col-sm-12 text-right">
+							<a  class="btn btn-outline-primary btn-cl btn-cl-secondary card-edit-sizing" href="{% url 'concept_update' concept.id %}" title="Edit concept">
+								Edit
+							</a> 						
+					</div>			
+			</div>			
+			{% endif %}		  	
+		</div>				  
 	<br> 
 	{% empty %}
 		<div class="row form-group">

--- a/CodeListLibrary_project/cll/templates/clinicalcode/concept/detail_combined.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/concept/detail_combined.html
@@ -163,7 +163,7 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 							{% endfor %}
 						{% endfor %}
 					</h2>
-					<span>{{ concept.author_highlighted|safe }}</span>					
+					<span><i>{{ concept.author_highlighted|safe }}</i></span>					
 					<br>
 					<br>
 				</div>
@@ -218,13 +218,34 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 						</span>		
 					</div>	
 				</div>	
-												
+				
 				<div class="row" style="margin-top: 10px;">
-					<div class="col-sm-2">Tags /Collections</div>
+					<div class="col-sm-2">Collections</div>
 					<div class="col-sm-10">
-						{% for tag in tags %}
-							<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
-						{% endfor %}		
+						{% if has_collections %}
+							{% for tag in tags %}
+								{% if tag.tag_type == 2 %}
+								<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
+								{% endif %}
+							{% endfor %}	
+						{% else %}
+							<span class="card-no-data">No collections</span>
+						{% endif %}		
+					</div>	
+				</div>
+				
+				<div class="row" style="margin-top: 10px;">
+					<div class="col-sm-2">Tags</div>
+					<div class="col-sm-10">
+						{% if has_tags %}
+							{% for tag in tags %}
+								{% if tag.tag_type == 1 %}
+								<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
+								{% endif %}
+							{% endfor %}	
+						{% else %}
+							<span class="card-no-data">No tags</span>
+						{% endif %}		
 					</div>	
 				</div>	
 								
@@ -259,7 +280,11 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 				<div class="col-sm-12 shadow-frame">
 					<h3 class="paneltitle" style="margin-top:20px; margin-bottom:20px"><span id="description"></span><strong>Description</strong></h3>
 					<div class="markdown-holder">
-						{{ concept.description_highlighted|markdownify }}
+						{% if concept.publication_doi_highlighted|safe != '' %}
+							{{ concept.description_highlighted|markdownify }}
+						{% else %}
+							<span class="card-no-data">No data available</span>
+						{% endif %}
 					</div>
 				</div>
 		
@@ -273,17 +298,29 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 					
 				    <div class="row" style="margin-top: 10px;">
 						<div  class="col-sm-3">Primary publication DOI</div>
+						{% if concept.publication_doi_highlighted|safe != '' %}
 						<div class="col-sm-9">{{ concept.publication_doi_highlighted|safe }}</div>
+						{% else %}
+						<div class="col-sm-9 card-no-data">No data available</div>
+						{% endif %}
 					</div>
 	
 					<div class="row" style="margin-top: 10px;">
 						<div  class="col-sm-3">Primary publication link</div>
+						{% if concept.publication_link_highlighted|safe != '' %}
 						<div class="col-sm-9">{{ concept.publication_link_highlighted|safe }}</div>
+						{% else %}
+						<div class="col-sm-9 card-no-data">No data available</div>
+						{% endif %}
 					</div>						
 							
 					<div class="row" style="margin-top: 10px;">
 						<div  class="col-sm-3">Secondary  publication link</div>
+						{% if concept.secondary_publication_links_highlighted|safe != '' %}
 						<div class="col-sm-9">{{ concept.secondary_publication_links_highlighted|safe }}</div>
+						{% else %}
+						<div class="col-sm-9 card-no-data">No data available</div>
+						{% endif %}
 					</div>
 
 					<div class="row" style="margin-top: 10px;">
@@ -294,10 +331,10 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 <!-- 							 </div> -->
 <!-- 							<input type="checkbox" {% if concept.paper_published %}checked="checked"{% endif %} disabled /> -->
 							{% if concept.paper_published %}
-								<span>&#10004;</span>
+								<span>Published &#10004;</span>
 <!-- 								<span class = "glyphicon glyphicon-ok"></span> -->
 							{% else %}
-								<span>&#10008;</span>
+								<span>Not published &#10008;</span>
 <!-- 								<span class = "glyphicon glyphicon-remove"></span> -->
 					 		{% endif %} 							
 						</div>
@@ -305,16 +342,20 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 					
 					<div class="row" style="margin-top: 10px;">
 						<div  class="col-sm-3">Source reference</div>
-						<div class="col-sm-9">
-							{{ concept.source_reference|highlight:q }}
-						</div>
+						{% if concept.source_reference|safe != '' %}
+						<div class="col-sm-9">{{ concept.source_reference|highlight:q }}</div>
+						{% else %}
+						<div class="col-sm-9 card-no-data">No data available</div>
+						{% endif %}
 					</div>
 					
 					<div class="row" style="margin-top: 10px;">
 						<div  class="col-sm-3">Citation requirements</div>
-						<div class="col-sm-9">
-							{{ concept.citation_requirements|highlight:q }}
-						</div>
+						{% if concept.citation_requirements|safe != '' %}
+						<div class="col-sm-9">{{ concept.citation_requirements|highlight:q }}</div>
+						{% else %}
+						<div class="col-sm-9 card-no-data">No data available</div>
+						{% endif %}
 					</div>
 
 				</div>
@@ -611,51 +652,53 @@ data-spy="scroll" data-target="#ConceptMenu" data-offset = "140"
 			
 				<div id="permissions" class="row">
 					<div  class="col-sm-3">Owner</div>
-					<div class="col-sm-3">
-						{{ concept.owner.username }}
+					<div class="col-sm-4">
+						<span>{{ concept.owner.username }}</span>
 					</div>
-					<div  class="col-sm-2">Owner access</div>
-					<div class="col-sm-4">								
+					<div class="col-sm-5 text-right">
 						{% if concept.owner_access == 1 %}	
-							<span>None</span>
+							<span class="tag label label-danger justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">None</span></span>
 						{% elif concept.owner_access == 2 %}
-							<span>View only</span>
+							<span class="tag label label-warning justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">View only</span></span>
 						{% elif concept.owner_access == 3 %}
-							<span>View and edit</span>
+							<span class="tag label label-success justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">View and edit</span></span>
 						{% else %}
-							
+							<span class="tag label label-success justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">Unknown</span></span>
 						{% endif %}
 					</div>
 				</div>
-				
+				<hr class="small-divider"/>
 				<div id="permissions" class="row">
 					<div  class="col-sm-3">Group</div>
-					<div class="col-sm-3">
-						{{ concept.group }}
-					</div>
-					<div  class="col-sm-2">Group access</div>
 					<div class="col-sm-4">
-						{% if concept.group_access == 1 %}	
-							<span>No access</span>
-						{% elif concept.group_access == 2 %}
-							<span>View only</span>
-						{% elif concept.group_access == 3 %}
-							<span>View and edit</span>
+						{% if concept.group %}
+						<span>{{ concept.group }}</span>
 						{% else %}
-							
+						<span>No associated group</span>
+						{% endif %}
+					</div>
+					<div class="col-sm-5 text-right">
+						{% if concept.group_access == 1 %}	
+							<span class="tag label label-danger justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">No Access</span></span>
+						{% elif concept.group_access == 2 %}
+							<span class="tag label label-warning justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">View only</span></span>
+						{% elif concept.group_access == 3 %}
+							<span class="tag label label-success justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">View and edit</span></span>
+						{% else %}
+							<span class="tag label label-success justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">Unknown</span></span>
 						{% endif %}
 					</div>
 				</div>
-				
+				<hr class="small-divider"/>
 				<div id="permissions" class="row">
-					<div  class="col-sm-3">Everyone else access</div>
+					<div  class="col-sm-3">Public access</div>
 					<div class="col-sm-9">
 						{% if concept.world_access == 1 %}	
-							<span>No access</span>
+							<span class="tag label label-danger">No access</span>
 						{% elif concept.world_access == 2 %}
-							<span>View only</span>
+							<span class="tag label label-warning">View only</span>
 						{% elif concept.world_access == 3 %}
-							<span>View and edit</span>
+							<span class="tag label label-success">View and edit</span>
 						{% else %}
 							
 						{% endif %}

--- a/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/detail_combined.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/detail_combined.html
@@ -224,22 +224,13 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                             {% endfor %}
                         {% endfor %}
                     </h2>
-                    <span>{{ phenotype.author_highlighted|safe }}</span>
+                    <span><i>{{ phenotype.author_highlighted|safe }}</i></span>
                     <br>
                     <br>
                 </div>
 
 
                 <div class="row"></div>
-                <div class="row" style="margin-top: 10px;">
-                    <div class="col-sm-2">Type</div>
-                    <div class="col-sm-10">
-					<span id="phenotype_type_div" phenotype_type="{{ phenotype.type }}">
-						{{ phenotype.type }}						
-					</span>
-                    </div>
-                </div>
-
                 <div class="row" style="margin-top: 10px;">
                     <div class="col-sm-2">ID</div>
                     <div class="col-sm-10">
@@ -248,6 +239,7 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
 					</span>
                     </div>
                 </div>
+
                 <div class="row" style="margin-top: 10px;">
                     <div class="col-sm-2">Version ID</div>
                     <div class="col-sm-10">
@@ -273,19 +265,30 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                     </div>
                 </div>
 
-
                 {% if user.is_authenticated %}
                     <div class="row" style="margin-top: 10px;">
                         <div class="col-sm-2">UUID:</div>
                         <div class="col-sm-10">
-								<span>
+								<code>
 									{{ phenotype.phenotype_uuid }}
-								</span>
+                                </code>
                         </div>
                     </div>
                 {% endif %}
 
-
+                <div class="row" style="margin-top: 10px;">
+                    <div class="col-sm-2">Type</div>
+                    <div class="col-sm-10">
+					<span id="phenotype_type_div" phenotype_type="{{ phenotype.type }}">
+                        {% if phenotype.type %}
+						<span class="badge phenotype-type-badge card-tag-sizing"><i><strong>{{ phenotype.type }}</i></strong></span>
+                        {% else %}
+                        <span class="card-no-data">Unknown type</span>
+                        {% endif %}
+					</span>
+                    </div>
+                </div>
+                
                 <div class="row" style="margin-top: 10px;">
                     <div class="col-sm-2">Data Sources</div>
                     <div class="col-sm-10">
@@ -306,7 +309,11 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
 	                <div class="row" style="margin-top: 10px;">
 	                    <div class="col-sm-2">Valid event data range</div>
 	                    <div class="col-sm-10">
-	                        {{ phenotype.valid_event_data_range }}
+                            {% if phenotype.valid_event_data_range|safe != '' %}
+	                            {{ phenotype.valid_event_data_range }}
+                            {% else %}
+                                <span class="card-no-data">No collections</span>
+                            {% endif %}
 	                    </div>
 	                </div>
                 {% endif %}
@@ -314,7 +321,13 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                 <div class="row" style="margin-top: 10px;">
                     <div class="col-sm-2">Sex</div>
                     <div class="col-sm-10">
-                        {{ phenotype.sex }}
+                        {% if gender|length %}
+                            {% for sex in gender %}
+                            <span class="badge gender-badge-{{ sex }}">
+                                {% if sex == "Male" %}♂{% else %}♀{% endif %}&nbsp;&nbsp;{{ sex }}
+                            </span>
+                            {% endfor %}
+                        {% endif %}
                     </div>
                 </div>
 
@@ -336,20 +349,45 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                 <div class="row" style="margin-top: 10px;">
                     <div class="col-sm-2">Coding system</div>
                     <div class="col-sm-10">
+                        {% if clinicalTerminologies|length %}
                         {% for ct in clinicalTerminologies %}
                             <span class="badge">{{ ct.name }}</span>
                         {% endfor %}
+                        {% else %}
+                        <span class="card-no-data">No associated codes</span>
+                        {% endif %}
                     </div>
                 </div>
 
-                <div class="row" style="margin-top: 10px;">
-                    <div class="col-sm-2">Tags /Collections</div>
-                    <div class="col-sm-10">
-                        {% for tag in tags %}
-                            <span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
-                        {% endfor %}
-                    </div>
-                </div>
+				<div class="row" style="margin-top: 10px;">
+					<div class="col-sm-2">Collections</div>
+					<div class="col-sm-10">
+						{% if has_collections %}
+							{% for tag in tags %}
+								{% if tag.tag_type == 2 %}
+								<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
+								{% endif %}
+							{% endfor %}	
+						{% else %}
+							<span class="card-no-data">No collections</span>
+						{% endif %}		
+					</div>	
+				</div>
+				
+				<div class="row" style="margin-top: 10px;">
+					<div class="col-sm-2">Tags</div>
+					<div class="col-sm-10">
+						{% if has_tags %}
+							{% for tag in tags %}
+								{% if tag.tag_type == 1 %}
+								<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
+								{% endif %}
+							{% endfor %}	
+						{% else %}
+							<span class="card-no-data">No tags</span>
+						{% endif %}		
+					</div>	
+				</div>	
 
             </div>
 
@@ -362,7 +400,11 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
             <div class="col-sm-12 shadow-frame">
                 <h3 class="paneltitle" style="margin-top:20px; margin-bottom:20px;"><span
                         id="definition"></span><strong>Definition</strong></h3>
+                {% if phenotype.description_highlighted|safe != '' %}
                 {{ phenotype.description_highlighted|markdownify }}
+                {% else %}
+                <span class="card-no-data">No data available</span>
+                {% endif %}
             </div>
 
 
@@ -437,6 +479,8 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                                 <li>{{ p|markdownify }}</li>
                             {% endfor %}
                         </ul>
+                    {% else %}
+                    <span class="card-no-data">No data available</span>
                     {% endif %}
                 </div>
 
@@ -454,6 +498,7 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                         id="CodeLists"></span><strong>Clinical Code List</strong>
                     <div class="dropdown btn-group" style="float: right;">
 
+                        {% if concept_data|length > 0 %}
                         <button {% if not user_can_export %} disabled
                                                              title="Component concept(s) deleted or revoked access!!" {% endif %}
                                                              type="button" class="btn btn-primary dropdown-toggle"
@@ -498,6 +543,7 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                                 </a>
                             </li>
                         </ul>
+                        {% endif %}
                     </div>
                 </h3>
 
@@ -508,12 +554,14 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                         <!-- component-tab-div -->
 
 
+                        {% if concept_data|length > 0 %}
                         <div class="accordion-option">
                             <a href="javascript:void(0)" class="toggle-accordion active" id="Expand_all">Expand All</a>
                             &nbsp;/&nbsp;
                             <a href="javascript:void(0)" class="toggle-accordion active" id="Collapse_all">Collapse
                                 All</a>
                         </div>
+                        {% endif %}
 
                         <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
                             {% for c in concept_data %}
@@ -625,7 +673,7 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
                                     </div>
                                 </div>
                             {% empty %}
-                                <div> no concepts</div>
+                                <span class="card-no-data">No data available</span>
                             {% endfor %}
                         </div>
 
@@ -689,58 +737,60 @@ data-spy="scroll" data-target="#PhenotypeMenu" data-offset = "140"
 						</div>
 -->
 
-                    <div id="permissions" class="row">
-                        <div class="col-sm-3 ">Owner</div>
-                        <div class="col-sm-3">
-                            {{ phenotype.owner.username }}
+                        <div id="permissions" class="row">
+                            <div  class="col-sm-3">Owner</div>
+                            <div class="col-sm-4">
+                                <span>{{ phenotype.owner.username }}</span>
+                            </div>
+                            <div class="col-sm-5 text-right">
+                                {% if phenotype.owner_access == 1 %}	
+                                    <span class="tag label label-danger justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">None</span></span>
+                                {% elif phenotype.owner_access == 2 %}
+                                    <span class="tag label label-warning justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">View only</span></span>
+                                {% elif phenotype.owner_access == 3 %}
+                                    <span class="tag label label-success justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">View and edit</span></span>
+                                {% else %}
+                                    <span class="tag label label-success justified-label"><i>Owner access:&nbsp;&nbsp;</i><span class="card-noweight">Unknown</span></span>
+                                {% endif %}
+                            </div>
                         </div>
-                        <div class="col-sm-3">Owner access</div>
-                        <div class="col-sm-3">
-                            {% if phenotype.owner_access == 1 %}
-                                <span>None</span>
-                            {% elif phenotype.owner_access == 2 %}
-                                <span>View only</span>
-                            {% elif phenotype.owner_access == 3 %}
-                                <span>View and edit</span>
-                            {% else %}
-
-                            {% endif %}
+                        <hr class="small-divider"/>
+                        <div id="permissions" class="row">
+                            <div  class="col-sm-3">Group</div>
+                            <div class="col-sm-4">
+                                {% if phenotype.group %}
+                                <span>{{ phenotype.group }}</span>
+                                {% else %}
+                                <span>No associated group</span>
+                                {% endif %}
+                            </div>
+                            <div class="col-sm-5 text-right">
+                                {% if phenotype.group_access == 1 %}	
+                                    <span class="tag label label-danger justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">No Access</span></span>
+                                {% elif phenotype.group_access == 2 %}
+                                    <span class="tag label label-warning justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">View only</span></span>
+                                {% elif phenotype.group_access == 3 %}
+                                    <span class="tag label label-success justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">View and edit</span></span>
+                                {% else %}
+                                    <span class="tag label label-success justified-label"><i>Group access:&nbsp;&nbsp;</i><span class="card-noweight text-right">Unknown</span></span>
+                                {% endif %}
+                            </div>
                         </div>
-                    </div>
-
-                    <div id="permissions" class="row">
-                        <div class="col-sm-3">Group</div>
-                        <div class="col-sm-3">
-                            {{ phenotype.group }}
+                        <hr class="small-divider"/>
+                        <div id="permissions" class="row">
+                            <div  class="col-sm-3">Public access</div>
+                            <div class="col-sm-9">
+                                {% if phenotype.world_access == 1 %}	
+                                    <span class="tag label label-danger">No access</span>
+                                {% elif phenotype.world_access == 2 %}
+                                    <span class="tag label label-warning">View only</span>
+                                {% elif phenotype.world_access == 3 %}
+                                    <span class="tag label label-success">View and edit</span>
+                                {% else %}
+                                    
+                                {% endif %}
+                            </div>
                         </div>
-                        <div class="col-sm-3">Group access</div>
-                        <div class="col-sm-3">
-                            {% if phenotype.group_access == 1 %}
-                                <span>No access</span>
-                            {% elif phenotype.group_access == 2 %}
-                                <span>View only</span>
-                            {% elif phenotype.group_access == 3 %}
-                                <span>View and edit</span>
-                            {% else %}
-
-                            {% endif %}
-                        </div>
-                    </div>
-
-                    <div id="permissions" class="row">
-                        <div class="col-sm-3">Everyone else access</div>
-                        <div class="col-sm-9">
-                            {% if phenotype.world_access == 1 %}
-                                <span>No access</span>
-                            {% elif phenotype.world_access == 2 %}
-                                <span>View only</span>
-                            {% elif phenotype.world_access == 3 %}
-                                <span>View and edit</span>
-                            {% else %}
-
-                            {% endif %}
-                        </div>
-                    </div>
 
                 </div>
             {% endif %}

--- a/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/phenotype_results.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/phenotype/phenotype_results.html
@@ -10,10 +10,19 @@
 			<div class="cl-card {% if phenotype.is_deleted is True %} cl-card-deleted{% endif %} {% cycle ' dark-div ' '' %}   "
                         {% if phenotype.approval_status == 1 and phenotype.owner_id == request.user.id or request.user|has_group:"Moderators" and phenotype.approval_status == 1 %}title="Waiting for approval"{% endif %}>
 				<div class="row form-group">
-					<div class="col-sm-12">
+					<div class="col-sm-8">
 						<a class="" href="{% url 'phenotype_history_detail' phenotype.id phenotype.history_id %}">
 						<span style='font-size: 22px;margin-top:0;'>{{ phenotype.friendly_id }} - {{ phenotype.name_highlighted|safe }}</span>
 						</a>				
+					</div>
+					<div class="col-sm-4 text-right">
+						<span class="badge card-date-badge">
+							{% if user.is_authenticated %}
+								<span class="card-date-block">Modified:</span><i class="card-noweight">{{ phenotype.modified|date:"Y-m-d" }}</i>
+							{% else %}	
+								<span class="card-date-block">Published:</span><i class="card-noweight">{{ phenotype.publish_date|date:"Y-m-d" }}</i>
+							{% endif %}
+						</span>
 					</div>
 				</div>
 				
@@ -26,51 +35,38 @@
 				</div>
 				
 				<div class="row form-group">
-					<div class="col-sm-4">
+					<div class="col-sm-4 text-justify">
 						<!-- CodingSystems -->
 						{% for cs in all_CodingSystems %}
 							{% for cs_id in phenotype.clinical_terminologies %}
 								{% if cs.id == cs_id %}
-							   		<span class="badge">{{ cs.name }}</span>
-							   	{% endif %}
+									<span class="badge card-coding-item"><i></i>{{ cs.name }}</span>
+								{% endif %}
 							{% endfor %}						
-						{% endfor %}	
+						{% endfor %}
 					</div>
-					<div class="col-sm-4">
-						<i><strong>{{ phenotype.type }}</i></strong>
+					<div class="col-sm-4 text-center">
+						<span class="badge phenotype-type-badge card-tag-sizing"><i><strong>{{ phenotype.type }}</i></strong></span>
+					</div>			
+					{% if phenotype.tags %}	
+					<div class="col-sm-4 text-right">
+						<!-- tags -->
+						{% for tag in allTags %}
+							{% for tag_id in phenotype.tags %}
+								{% if tag.id == tag_id %}
+										<span class="tag label label-{{ tag.get_display_display }} card-tag-sizing">#{{ tag.description }}</span>
+									{% endif %}
+							{% endfor %}						
+						{% endfor %}			
 					</div>	
-					<div class="col-sm-4">
-						{% if user.is_authenticated %}
-							<i>{{ phenotype.modified|date:"Y-m-d" }}</i>
-						{% else %}	
-							<i>{{ phenotype.publish_date|date:"Y-m-d" }}</i>
-						{% endif %}
-					</div>
+					{% endif %}	
 
 <!-- 					<div class="col-sm-2 text-right">
 						{% if user.is_authenticated and phenotype.is_published == 1 %}
 							<span title="{{ phenotype.published }} on {{ phenotype.publish_date|date:"Y-m-d" }}" style="text-align: right;" ><i class="fa fa-paper-plane" aria-hidden="true"></i></span>
 						{% endif %}	
 					</div>	 -->
-				</div>
-				
-			{% if phenotype.tags %}
-				<div class="row form-group">
-					<div class="col-sm-12">
-						<!-- tags -->
-						{% for tag in allTags %}
-							{% for tag_id in phenotype.tags %}
-								{% if tag.id == tag_id %}
-							   		<span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
-							   	{% endif %}
-							{% endfor %}						
-						{% endfor %}			
-										
-					</div>	
 				</div>						
-			{% endif %}								
-					
-				
 	</div>				  
 	<br> 
 	{% empty %}

--- a/CodeListLibrary_project/cll/templates/clinicalcode/phenotypeworkingset/workingset_results.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/phenotypeworkingset/workingset_results.html
@@ -10,10 +10,19 @@
   <div class="cl-card {% if workingset.is_deleted is True %} cl-card-deleted{% endif %} {% cycle ' dark-div ' '' %}   "
                     {% if workingset.approval_status == 1 and workingset.owner_id == request.user.id or request.user|has_group:"Moderators" and workingset.approval_status == 1 %}title="Waiting for approval"{% endif %}>
     <div class="row form-group">
-      <div class="col-sm-12">
+      <div class="col-sm-8">
         <a class="" href="{% url 'phenotypeworkingset_history_detail' workingset.id workingset.history_id %}">
         <span style='font-size: 22px;margin-top:0;'>{{ workingset.id }} - {{ workingset.name_highlighted|safe }}</span>
         </a>				
+      </div>
+      <div class="col-sm-4 text-right">
+        <span class="badge card-date-badge">
+          {% if user.is_authenticated %}
+            <span class="card-date-block">Modified:</span><i class="card-noweight">{{ workingset.modified|date:"Y-m-d" }}</i>
+          {% else %}	
+            <span class="card-date-block">Published:</span><i class="card-noweight">{{ workingset.publish_date|date:"Y-m-d" }}</i>
+          {% endif %}
+        </span>
       </div>
     </div>
     
@@ -24,44 +33,17 @@
       </div>
 
     </div>
-    
     <div class="row form-group">
-      <div class="col-sm-4">
-        <!-- CodingSystems -->
-  <!-- 						{% for cs in all_CodingSystems %} -->
-  <!-- 							{% for cs_id in phenotype.clinical_terminologies %} -->
-  <!-- 								{% if cs.id == cs_id %} -->
-  <!-- 							   		<span class="badge">{{ cs.name }}</span> -->
-  <!-- 							   	{% endif %} -->
-  <!-- 							{% endfor %}						 -->
-  <!-- 						{% endfor %}	 -->
-      </div>
-      <div class="col-sm-4">
-        <i><strong>{{ workingset.type|get_ws_type_name }}</i></strong>
-      </div>	
-      <div class="col-sm-4">
-        {% if user.is_authenticated %}
-          <i>{{ workingset.modified|date:"Y-m-d" }}</i>
-        {% else %}	
-          <i>{{ workingset.publish_date|date:"Y-m-d" }}</i>
-        {% endif %}
-      </div>
-
-  <!-- 					<div class="col-sm-2 text-right">
-        {% if user.is_authenticated and workingset.is_published == 1 %}
-          <span title="{{ workingset.published }} on {{ workingset.publish_date|date:"Y-m-d" }}" style="text-align: right;" ><i class="fa fa-paper-plane" aria-hidden="true"></i></span>
-        {% endif %}	
-      </div>	 -->
-    </div>
-    
-  {% if workingset.collections or workingset.tags %}
-    <div class="row form-group">
-      <div class="col-sm-12">
+      <div class="col-sm-4 text-left">
+        <span class="badge phenotype-type-badge card-tag-sizing"><i><strong>{{ workingset.type|get_ws_type_name }}</i></strong></span>
+      </div>			
+      {% if workingset.collections or workingset.tags %}
+      <div class="col-sm-8 text-right">
         <!-- collections -->
         {% for tag in allTags %}
           {% for tag_id in workingset.collections %}
             {% if tag.id == tag_id %}
-                <span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
+                <span class="tag label label-{{ tag.get_display_display }} card-tag-sizing">#{{ tag.description }}</span>
               {% endif %}
           {% endfor %}						
         {% endfor %}			
@@ -70,16 +52,14 @@
         {% for tag in allTags %}
           {% for tag_id in workingset.tags %}
             {% if tag.id == tag_id %}
-                <span class="tag label label-{{ tag.get_display_display }}">{{ tag.description }}</span>
+                <span class="tag label label-{{ tag.get_display_display }} card-tag-sizing">#{{ tag.description }}</span>
               {% endif %}
           {% endfor %}						
         {% endfor %}			
                 
-      </div>	
-    </div>						
-  {% endif %}								
-      
-    
+      </div>			
+      {% endif %}						
+    </div>			
   </div>				  
   <br> 
   {% empty %}


### PR DESCRIPTION
Merge to base of #875, now able to merge to branch ```working-set-feature-master```

# Contains
- [x] Implements tasks from #885 
- [x] Fixes issues from #888 

# Details of #885  
1. [x] ```Collections``` and ```Tags``` are currently displayed as one unified list in the frontend → will be split into two separate tag lists, and the section will be hidden if both lists are empty
    - Handled by server
    - Changes to ```detail_combined.html``` of Phenotype, Concept and Workingset class
2. [x] ```Gender``` of phenotypes/concepts are displayed as strings → should be presented as tags
    - Changes to ```detail_combined.html``` of Phenotype class
3. [x] ```Phenotype type``` is displayed as a string → should be presented as a tag
    - Changes to ```phenotype_results.html```, ```workingset_results.html``` and assoc. detail pages
4. [x] The result cards for Phenotype, Concepts and Working Sets present the ```date```, which can represent either the ```date``` it was ```modified``` or the date it was ```published``` → this modifier should be presented to the client
    - Handled by template
5. [x] Update result cards style to improve readability of ```type```, ```date```, ```codes```, ```tags``` & ```collections```
    - Changes to ```phenotype_results.html```, ```concept_results.html``` and ```workingset_results.html```
6. [x] ```UUID``` restyled as code
    - Changes to ```detail_combined.html``` of Phenotype class
7. [x] Sections are hidden if no data is present, or we explain to the client that we do not have sufficient data for this section
    - Handled by template, changes to various assoc. html files