### PR TITLE
Finalised endpoints to match previous functionality, added templates & matched to R package

### DIFF
--- a/CodeListLibrary_project/clinicalcode/api/urls.py
+++ b/CodeListLibrary_project/clinicalcode/api/urls.py
@@ -13,7 +13,7 @@ from django.urls import re_path as url
 from django.urls import include
 from rest_framework import routers
 
-from .views import Concept, DataSource, Phenotype, View, WorkingSet, PhenotypeWorkingSet, GenericEntity
+from .views import Concept, DataSource, Phenotype, View, WorkingSet, PhenotypeWorkingSet, GenericEntity, Template
 
 from rest_framework import permissions
 from drf_yasg.generators import OpenAPISchemaGenerator
@@ -198,61 +198,61 @@ urlpatterns += [
     #----------------------------------------------------------
     # --- phenotypes   ----------------------------------------
     #----------------------------------------------------------
-    url(r'^phenotypes/(?P<primary_key>PH\d+)/export/codes/$',
-        GenericEntity.get_entity_detail, { 'field': 'codes' },
-        name='api_export_phenotype_codes_latestVersion'),
-    url(r'^phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/export/codes/$',
-        GenericEntity.get_entity_detail, { 'field': 'codes' },
-        name='api_export_phenotype_codes_byVersionID'),
+    # url(r'^phenotypes/(?P<primary_key>PH\d+)/export/codes/$',
+    #     GenericEntity.get_entity_detail, { 'field': 'codes' },
+    #     name='api_export_phenotype_codes_latestVersion'),
+    # url(r'^phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/export/codes/$',
+    #     GenericEntity.get_entity_detail, { 'field': 'codes' },
+    #     name='api_export_phenotype_codes_byVersionID'),
         
-    url(r'^public/phenotypes/(?P<primary_key>PH\d+)/export/codes/$',
-        GenericEntity.get_entity_detail, { 'field': 'codes' },
-        name='api_export_published_phenotype_codes_latestVersion'),
-    url(r'^public/phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/export/codes/$',
-        GenericEntity.get_entity_detail, { 'field': 'codes' },
-        name='api_export_published_phenotype_codes'),
+    # url(r'^public/phenotypes/(?P<primary_key>PH\d+)/export/codes/$',
+    #     GenericEntity.get_entity_detail, { 'field': 'codes' },
+    #     name='api_export_published_phenotype_codes_latestVersion'),
+    # url(r'^public/phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/export/codes/$',
+    #     GenericEntity.get_entity_detail, { 'field': 'codes' },
+    #     name='api_export_published_phenotype_codes'),
 
-    #==== search concepts/published phenotypes =====
-    url(r'^phenotypes/$', 
-        GenericEntity.get_generic_entities, { 'should_paginate': False },
-        name='phenotypes'),
-    url(r'^phenotypes/(?P<primary_key>PH\d+)/$', 
-        GenericEntity.get_entity_detail, 
-        name='phenotype_by_id'),
+    # #==== search concepts/published phenotypes =====
+    # url(r'^phenotypes/$', 
+    #     GenericEntity.get_generic_entities, { 'should_paginate': False },
+    #     name='phenotypes'),
+    # url(r'^phenotypes/(?P<primary_key>PH\d+)/$', 
+    #     GenericEntity.get_entity_detail, 
+    #     name='phenotype_by_id'),
 
-    # search published phenotypes
-    url(r'^public/phenotypes/$',
-        GenericEntity.get_generic_entities, { 'should_paginate': False },
-        name='api_published_phenotypes'),
-    url(r'^public/phenotypes/(?P<primary_key>PH\d+)/$',
-        GenericEntity.get_entity_detail, 
-        name='api_published_phenotype_by_id'),
-    #===============================================
+    # # search published phenotypes
+    # url(r'^public/phenotypes/$',
+    #     GenericEntity.get_generic_entities, { 'should_paginate': False },
+    #     name='api_published_phenotypes'),
+    # url(r'^public/phenotypes/(?P<primary_key>PH\d+)/$',
+    #     GenericEntity.get_entity_detail, 
+    #     name='api_published_phenotype_by_id'),
+    # #===============================================
 
-    # my phenotype detail
-    # if only phenotype_id is provided, get the latest version
-    url(r'^phenotypes/(?P<primary_key>PH\d+)/detail/$',
-        GenericEntity.get_entity_detail, 
-        name='api_phenotype_detail'),
-    url(r'^public/phenotypes/(?P<primary_key>PH\d+)/detail/$',
-        GenericEntity.get_entity_detail, 
-        name='api_phenotype_detail_public'),
+    # # my phenotype detail
+    # # if only phenotype_id is provided, get the latest version
+    # url(r'^phenotypes/(?P<primary_key>PH\d+)/detail/$',
+    #     GenericEntity.get_entity_detail, 
+    #     name='api_phenotype_detail'),
+    # url(r'^public/phenotypes/(?P<primary_key>PH\d+)/detail/$',
+    #     GenericEntity.get_entity_detail, 
+    #     name='api_phenotype_detail_public'),
 
-    # get specific version
-    url(r'^phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
-        GenericEntity.get_entity_detail, 
-        name='api_phenotype_detail_version'),
-    url(r'^public/phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
-        GenericEntity.get_entity_detail, 
-        name='api_phenotype_detail_version_public'),
+    # # get specific version
+    # url(r'^phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
+    #     GenericEntity.get_entity_detail, 
+    #     name='api_phenotype_detail_version'),
+    # url(r'^public/phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
+    #     GenericEntity.get_entity_detail, 
+    #     name='api_phenotype_detail_version_public'),
 
-    # show versions
-    url(r'^phenotypes/(?P<primary_key>PH\d+)/get-versions/$',
-        GenericEntity.get_generic_entity_version_history,
-        name='get_phenotype_versions'),
-    url(r'^public/phenotypes/(?P<primary_key>PH\d+)/get-versions/$',
-        GenericEntity.get_generic_entity_version_history,
-        name='get_phenotype_versions_public'),
+    # # show versions
+    # url(r'^phenotypes/(?P<primary_key>PH\d+)/get-versions/$',
+    #     GenericEntity.get_generic_entity_version_history,
+    #     name='get_phenotype_versions'),
+    # url(r'^public/phenotypes/(?P<primary_key>PH\d+)/get-versions/$',
+    #     GenericEntity.get_generic_entity_version_history,
+    #     name='get_phenotype_versions_public'),
 
     # ---------------------------------------------------------
     # ---  data sources  --------------------------------------
@@ -415,44 +415,82 @@ if not settings.CLL_READ_ONLY:
 if settings.IS_DEMO or settings.IS_DEVELOPMENT_PC:
     urlpatterns += [
         # List all entities
-        url(r'^entity/$',
+        url(r'^phenotypes/$',
             GenericEntity.get_generic_entities,
             name='api_generic_entity'),
+        url(r'^public/phenotypes/$',
+            GenericEntity.get_generic_entities, { 'public': True },
+            name='api_generic_entity_public'),
 
         # Generic entity detail
-        url(r'^entity/(?P<primary_key>\w+)/detail/$',
+        url(r'^phenotypes/(?P<primary_key>\w+)/detail/$',
             GenericEntity.get_entity_detail,
             name='api_generic_entity_detail'),
+        url(r'^public/phenotypes/(?P<primary_key>\w+)/detail/$',
+            GenericEntity.get_entity_detail, { 'public': True },
+            name='api_generic_entity_detail_public'),
 
         # Get specific entity version
-        url(r'^entity/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
+        url(r'^phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
             GenericEntity.get_entity_detail,
             name='api_generic_entity_detail_by_version'),
+        url(r'^public/phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
+            GenericEntity.get_entity_detail, { 'public': True },
+            name='api_generic_entity_detail_by_version_public'),
 
         # Export specific entity field
-        url(r'^entity/(?P<primary_key>\w+)/export/(?P<field>\w+)/$',
+        url(r'^phenotypes/(?P<primary_key>\w+)/export/(?P<field>\w+)/$',
             GenericEntity.get_entity_detail,
             name='get_generic_entity_field'),
+        url(r'^public/phenotypes/(?P<primary_key>\w+)/export/(?P<field>\w+)/$',
+            GenericEntity.get_entity_detail, { 'public': True },
+            name='get_generic_entity_field_public'),
 
-        # Get specific entity version
-        url(r'^entity/(?P<primary_key>\w+)/version/(?P<historical_id>\d+)/export/(?P<field>\w+)/$',
+        # Export specific entity field from specific entity version
+        url(r'^phenotypes/(?P<primary_key>\w+)/version/(?P<historical_id>\d+)/export/(?P<field>\w+)/$',
             GenericEntity.get_entity_detail,
             name='get_generic_entity_field_by_version'),
+        url(r'^public/phenotypes/(?P<primary_key>\w+)/version/(?P<historical_id>\d+)/export/(?P<field>\w+)/$',
+            GenericEntity.get_entity_detail, { 'public': True },
+            name='get_generic_entity_field_by_version_public'),
 
         # Show entity versions
-        url(r'^entity/(?P<primary_key>\w+)/get-versions/$',
+        url(r'^phenotypes/(?P<primary_key>\w+)/get-versions/$',
             GenericEntity.get_generic_entity_version_history,
+            name='get_generic_entity_versions'),
+        url(r'^public/phenotypes/(?P<primary_key>\w+)/get-versions/$',
+            GenericEntity.get_generic_entity_version_history, { 'public': True },
             name='get_generic_entity_versions_public'),
 
         # Create entity
-        url(r'^entity/create/$',
+        url(r'^phenotypes/create/$',
             GenericEntity.create_generic_entity,
             name='create_generic_entity'),
 
         # Update entity
-        url(r'^entity/update/$',
+        url(r'^phenotypes/update/$',
             GenericEntity.update_generic_entity,
             name='update_generic_entity'),
+
+        # Get templates
+        url(r'^templates/$', 
+            Template.get_templates,
+            name='get_templates'),
+
+        # Get template versions
+        url(r'^templates/(?P<primary_key>\d+)/get-versions/$', 
+            Template.get_template_version_history,
+            name='get_template_version_history'),
+
+        # Get template detail
+        url(r'^templates/(?P<primary_key>\d+)/detail/$', 
+            Template.get_template,
+            name='get_template_detail'),
+
+        # Get template detail with history
+        url(r'^templates/(?P<primary_key>\d+)/version/(?P<history_id>\d+)/detail/$', 
+            Template.get_template,
+            name='get_template_detail_from_version'),
     ]
 
 ####### M Elmessary ################
@@ -499,7 +537,6 @@ if settings.IS_DEMO or settings.IS_DEVELOPMENT_PC:
         name='ge_api_export_published_phenotype_codes'),
     
     ]
-    
 
 #======== Generic Entity create/update ===================
 if not settings.CLL_READ_ONLY:    

--- a/CodeListLibrary_project/clinicalcode/api/urls.py
+++ b/CodeListLibrary_project/clinicalcode/api/urls.py
@@ -418,49 +418,31 @@ if settings.IS_DEMO or settings.IS_DEVELOPMENT_PC:
         url(r'^phenotypes/$',
             GenericEntity.get_generic_entities,
             name='api_generic_entity'),
-        url(r'^public/phenotypes/$',
-            GenericEntity.get_generic_entities, { 'public': True },
-            name='api_generic_entity_public'),
 
         # Generic entity detail
         url(r'^phenotypes/(?P<primary_key>\w+)/detail/$',
             GenericEntity.get_entity_detail,
             name='api_generic_entity_detail'),
-        url(r'^public/phenotypes/(?P<primary_key>\w+)/detail/$',
-            GenericEntity.get_entity_detail, { 'public': True },
-            name='api_generic_entity_detail_public'),
 
         # Get specific entity version
         url(r'^phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
             GenericEntity.get_entity_detail,
             name='api_generic_entity_detail_by_version'),
-        url(r'^public/phenotypes/(?P<primary_key>PH\d+)/version/(?P<historical_id>\d+)/detail/$',
-            GenericEntity.get_entity_detail, { 'public': True },
-            name='api_generic_entity_detail_by_version_public'),
 
         # Export specific entity field
         url(r'^phenotypes/(?P<primary_key>\w+)/export/(?P<field>\w+)/$',
             GenericEntity.get_entity_detail,
             name='get_generic_entity_field'),
-        url(r'^public/phenotypes/(?P<primary_key>\w+)/export/(?P<field>\w+)/$',
-            GenericEntity.get_entity_detail, { 'public': True },
-            name='get_generic_entity_field_public'),
 
         # Export specific entity field from specific entity version
         url(r'^phenotypes/(?P<primary_key>\w+)/version/(?P<historical_id>\d+)/export/(?P<field>\w+)/$',
             GenericEntity.get_entity_detail,
             name='get_generic_entity_field_by_version'),
-        url(r'^public/phenotypes/(?P<primary_key>\w+)/version/(?P<historical_id>\d+)/export/(?P<field>\w+)/$',
-            GenericEntity.get_entity_detail, { 'public': True },
-            name='get_generic_entity_field_by_version_public'),
 
         # Show entity versions
         url(r'^phenotypes/(?P<primary_key>\w+)/get-versions/$',
             GenericEntity.get_generic_entity_version_history,
             name='get_generic_entity_versions'),
-        url(r'^public/phenotypes/(?P<primary_key>\w+)/get-versions/$',
-            GenericEntity.get_generic_entity_version_history, { 'public': True },
-            name='get_generic_entity_versions_public'),
 
         # Create entity
         url(r'^phenotypes/create/$',

--- a/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
+++ b/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
@@ -112,22 +112,13 @@ def update_generic_entity(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticatedOrReadOnly])
-def get_generic_entity_version_history(request, primary_key=None, public=False):
+def get_generic_entity_version_history(request, primary_key=None):
     '''
     
     '''
     user_authed = False
     if request.user and not request.user.is_anonymous:
         user_authed = True
-    
-    if not public and not user_authed:
-        return Response(
-            data={
-                'message': 'Permission denied'
-            },
-            content_type='json',
-            status=status.HTTP_403_FORBIDDEN
-        )
     
     # Check if primary_key is valid, i.e. matches regex '^[a-zA-Z]\d+'
     entity_id_response = api_utils.is_malformed_entity_id(primary_key)
@@ -148,7 +139,7 @@ def get_generic_entity_version_history(request, primary_key=None, public=False):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticatedOrReadOnly])
-def get_generic_entities(request, should_paginate=False, public=False):
+def get_generic_entities(request, should_paginate=False):
     '''
     
     '''
@@ -156,17 +147,12 @@ def get_generic_entities(request, should_paginate=False, public=False):
     if request.user and not request.user.is_anonymous:
         user_authed = True
 
-    if not public and not user_authed:
-        return Response(
-            data={
-                'message': 'Permission denied'
-            },
-            content_type='json',
-            status=status.HTTP_403_FORBIDDEN
-        )
-
     # Get all accessible entities for this user
-    entities = permission_utils.get_accessible_entities(request)
+    entities = permission_utils.get_accessible_entities(
+        request, 
+        consider_user_perms=False, 
+        status=[constants.APPROVAL_STATUS.ANY]
+    )
     if not entities.exists():
         return Response([], status=status.HTTP_200_OK)
     
@@ -275,27 +261,13 @@ def get_generic_entities(request, should_paginate=False, public=False):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticatedOrReadOnly])
-def get_entity_detail(
-    request, 
-    primary_key, 
-    historical_id=None, 
-    field=None, 
-    public=False):
+def get_entity_detail(request, primary_key, historical_id=None, field=None):
     '''
 
     '''
     user_authed = False
     if request.user and not request.user.is_anonymous:
         user_authed = True
-    
-    if not public and not user_authed:
-        return Response(
-            data={
-                'message': 'Permission denied'
-            },
-            content_type='json',
-            status=status.HTTP_403_FORBIDDEN
-        )
 
     # Check if primary_key is valid, i.e. matches regex '^[a-zA-Z]\d+'
     entity_id_response = api_utils.is_malformed_entity_id(primary_key)

--- a/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
+++ b/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
@@ -1,7 +1,7 @@
-from rest_framework import status
-from rest_framework.decorators import (api_view, authentication_classes, permission_classes)
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.decorators import (api_view, permission_classes)
+from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework import status
 from drf_yasg.utils import swagger_auto_schema
 from django.db.models import Q
 from django.conf import settings
@@ -10,28 +10,20 @@ from ...models import *
 from ...entity_utils import permission_utils
 from ...entity_utils import template_utils
 from ...entity_utils import search_utils
-from ...entity_utils import create_utils
 from ...entity_utils import api_utils
 from ...entity_utils import gen_utils
 from ...entity_utils import constants
-
-from ...db_utils import *
-from clinicalcode.entity_utils import entity_db_utils
-from ...permissions import *
-from ...utils import *
-from ..serializers import *
-from .View import *
-from drf_yasg.utils import swagger_auto_schema
 
 ''' Create/Update GenericEntity '''
 
 @swagger_auto_schema(method='post', auto_schema=None)
 @api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def create_generic_entity(request):
     '''
     
     '''
-    if is_member(request.user, group_name='ReadOnlyUsers') or settings.CLL_READ_ONLY:
+    if permission_utils.is_member(request.user, 'ReadOnlyUsers') or settings.CLL_READ_ONLY:
         return Response(
             data={
                 'message': 'Permission denied'
@@ -43,26 +35,41 @@ def create_generic_entity(request):
     form = api_utils.validate_api_create_update_form(
         request, method=constants.FORM_METHODS.CREATE.value
     )
-    
+    if isinstance(form, Response):
+        return form
+        
     entity = api_utils.create_update_from_api_form(request, form)
+    if isinstance(entity, Response):
+        return entity
+    
+    entity_data = {
+        'id': entity.id,
+        'version_id': entity.history_id,
+        'created': entity.created,
+        'updated': entity.updated,
+    }
+    if template_utils.get_entity_field(entity, 'concept_information'):
+        concept_data = api_utils.get_concept_versions_from_entity(entity)
+        entity_data = entity_data | {
+            'concepts': concept_data
+        }
+
     return Response(
         data={
             'message': 'Successfully created entity',
-            'entity': {
-                'id': entity.id,
-                'version_id': entity.history_id
-            }
+            'entity': entity_data
         },
         status=status.HTTP_201_CREATED
     )
 
 @swagger_auto_schema(method='put', auto_schema=None)
 @api_view(['PUT'])
+@permission_classes([IsAuthenticated])
 def update_generic_entity(request):
     '''
     
     '''
-    if is_member(request.user, group_name='ReadOnlyUsers') or settings.CLL_READ_ONLY:
+    if permission_utils.is_member(request.user, 'ReadOnlyUsers') or settings.CLL_READ_ONLY:
         return Response(
             data={
                 'message': 'Permission denied'
@@ -74,15 +81,29 @@ def update_generic_entity(request):
     form = api_utils.validate_api_create_update_form(
         request, method=constants.FORM_METHODS.UPDATE.value
     )
+    if isinstance(form, Response):
+        return form
 
     entity = api_utils.create_update_from_api_form(request, form)
+    if isinstance(entity, Response):
+        return entity
+    
+    entity_data = {
+        'id': entity.id,
+        'version_id': entity.history_id,
+        'created': entity.created,
+        'updated': entity.updated,
+    }
+    if template_utils.get_entity_field(entity, 'concept_information'):
+        concept_data = api_utils.get_concept_versions_from_entity(entity)
+        entity_data = entity_data | {
+            'concepts': concept_data
+        }
+
     return Response(
         data={
             'message': 'Successfully updated entity',
-            'entity': {
-                'id': entity.id,
-                'version_id': entity.history_id
-            }
+            'entity': entity_data
         },
         status=status.HTTP_201_CREATED
     )
@@ -91,10 +112,23 @@ def update_generic_entity(request):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticatedOrReadOnly])
-def get_generic_entity_version_history(request, primary_key=None):
+def get_generic_entity_version_history(request, primary_key=None, public=False):
     '''
     
     '''
+    user_authed = False
+    if request.user and not request.user.is_anonymous:
+        user_authed = True
+    
+    if not public and not user_authed:
+        return Response(
+            data={
+                'message': 'Permission denied'
+            },
+            content_type='json',
+            status=status.HTTP_403_FORBIDDEN
+        )
+    
     # Check if primary_key is valid, i.e. matches regex '^[a-zA-Z]\d+'
     entity_id_response = api_utils.is_malformed_entity_id(primary_key)
     if isinstance(entity_id_response, Response):
@@ -114,17 +148,62 @@ def get_generic_entity_version_history(request, primary_key=None):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticatedOrReadOnly])
-def get_generic_entities(request, should_paginate=True):
+def get_generic_entities(request, should_paginate=False, public=False):
     '''
     
     '''
+    user_authed = False
     if request.user and not request.user.is_anonymous:
         user_authed = True
+
+    if not public and not user_authed:
+        return Response(
+            data={
+                'message': 'Permission denied'
+            },
+            content_type='json',
+            status=status.HTTP_403_FORBIDDEN
+        )
 
     # Get all accessible entities for this user
     entities = permission_utils.get_accessible_entities(request)
     if not entities.exists():
         return Response([], status=status.HTTP_200_OK)
+    
+    # Filter by template id and version
+    template_id = request.query_params.get('template_id', None)
+    template_version_id = request.query_params.get('template_version_id', None)
+    if template_id:
+        template = Template.objects.filter(id=template_id)
+        if not template.exists():
+            return Response(
+                data={
+                    'message': 'Template with specified id does not exist'
+                },
+                content_type='json',
+                status=status.HTTP_404_NOT_FOUND
+            )
+        
+        template = template.first()
+        if template_version_id:
+            template = template.history.filter(template_version=template_version_id)
+            if not template.exists():
+                return Response(
+                    data={
+                        'message': 'Template with specified version id does not exist'
+                    },
+                    content_type='json',
+                    status=status.HTTP_404_NOT_FOUND
+                )
+            
+            template = template.latest()
+            entities = entities.filter(
+                template__id=template.id, template_version=template.template_version
+            )
+        else:
+            entities = entities.filter(
+                template__id=template.id
+            )
 
     # Build query from searchable GenericEntity template fields
     templates = Template.objects.all()
@@ -143,7 +222,7 @@ def get_generic_entities(request, should_paginate=True):
             entities, search, fuzzy=False, order_by_relevance=False
         )
 
-    # Exit early if metadata queries do not match
+    # Exit early if queries do not match
     if not entities.exists():
         return Response([], status=status.HTTP_200_OK)
     
@@ -196,12 +275,27 @@ def get_generic_entities(request, should_paginate=True):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticatedOrReadOnly])
-def get_entity_detail(request, primary_key, historical_id=None, field=None):
+def get_entity_detail(
+    request, 
+    primary_key, 
+    historical_id=None, 
+    field=None, 
+    public=False):
     '''
 
     '''
+    user_authed = False
     if request.user and not request.user.is_anonymous:
         user_authed = True
+    
+    if not public and not user_authed:
+        return Response(
+            data={
+                'message': 'Permission denied'
+            },
+            content_type='json',
+            status=status.HTTP_403_FORBIDDEN
+        )
 
     # Check if primary_key is valid, i.e. matches regex '^[a-zA-Z]\d+'
     entity_id_response = api_utils.is_malformed_entity_id(primary_key)
@@ -261,6 +355,13 @@ def get_entity_detail(request, primary_key, historical_id=None, field=None):
     )
 
 ### M. Elmessary  ############
+
+from ...db_utils import *
+from clinicalcode.entity_utils import entity_db_utils
+from ...permissions import *
+from ...utils import *
+from ..serializers import *
+from .View import *
 
 # show generic_entity detail
 #=============================================================
@@ -620,5 +721,3 @@ def export_phenotype_codes_byVersionID(request, pk, history_id=None):
 
 
 ##################################################################################
-
-

--- a/CodeListLibrary_project/clinicalcode/api/views/Template.py
+++ b/CodeListLibrary_project/clinicalcode/api/views/Template.py
@@ -1,0 +1,163 @@
+from rest_framework.decorators import (api_view, permission_classes)
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+from django.conf import settings
+
+from ...models import *
+from ...entity_utils import permission_utils
+from ...entity_utils import api_utils
+from ...entity_utils import template_utils
+from ...entity_utils import constants
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_templates(request):
+  '''
+  
+  '''
+  if permission_utils.is_member(request.user, 'ReadOnlyUsers') or settings.CLL_READ_ONLY:
+    return Response(
+      data={
+        'message': 'Permission denied'
+      },
+      content_type='json',
+      status=status.HTTP_403_FORBIDDEN
+    )
+    
+  templates = Template.objects.all()
+  
+  result = []
+  for template in templates:
+    result.append({
+      'id': template.id,
+      'version_id': template.template_version,
+      'name': template.name,
+      'description': template.description,
+      'versions': api_utils.get_template_versions(template.id)
+    })
+
+  return Response(
+    data=result,
+    status=status.HTTP_200_OK
+  )
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_template_version_history(request, primary_key):
+  '''
+  
+  '''
+  if permission_utils.is_member(request.user, 'ReadOnlyUsers') or settings.CLL_READ_ONLY:
+    return Response(
+      data={
+        'message': 'Permission denied'
+      },
+      content_type='json',
+      status=status.HTTP_403_FORBIDDEN
+    )
+  
+  template = Template.objects.filter(id=primary_key)
+  if not template.exists():
+    return Response(
+      data={
+        'message': 'Template with specified id does not exist'
+      },
+      content_type='json',
+      status=status.HTTP_404_NOT_FOUND
+    )
+  template = template.first()
+
+  return Response(
+    data={
+      'id': template.id,
+      'versions': api_utils.get_template_versions(template.id)
+    },
+    status=status.HTTP_200_OK
+  )
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_template(request, primary_key, history_id=None):
+  '''
+  
+  '''
+  if permission_utils.is_member(request.user, 'ReadOnlyUsers') or settings.CLL_READ_ONLY:
+    return Response(
+      data={
+        'message': 'Permission denied'
+      },
+      content_type='json',
+      status=status.HTTP_403_FORBIDDEN
+    )
+  
+  template = Template.objects.filter(id=primary_key)
+  if not template.exists():
+    return Response(
+      data={
+        'message': 'Template with specified id does not exist'
+      },
+      content_type='json',
+      status=status.HTTP_404_NOT_FOUND
+    )
+  template = template.first()
+  
+  if history_id:
+    template = template.history.filter(template_version=history_id)
+    if not template.exists():
+        return Response(
+            data={
+                'message': 'Template with specified version id does not exist'
+            },
+            content_type='json',
+            status=status.HTTP_404_NOT_FOUND
+        )
+    template = template.latest()
+    
+  template_fields = template_utils.try_get_content(template.definition, 'fields')
+  
+  formatted_fields = []
+  for field, definition in template_fields.items():
+    is_base_field = template_utils.try_get_content(definition, 'is_base_field')
+    if is_base_field:
+      if field in constants.metadata:
+        definition = constants.metadata[field]
+      else:
+        continue
+
+    is_active = template_utils.try_get_content(definition, 'active')
+    if not is_active:
+      continue
+
+    validation = template_utils.try_get_content(definition, 'validation')
+    if validation is None:
+      continue
+
+    field_type = template_utils.try_get_content(validation, 'type')
+    if field_type is None:
+      continue
+
+    field_data = {
+      'field_name': field,
+      'field_type': field_type,
+      'field_description': template_utils.try_get_content(definition, 'description'),
+      'field_mandatory': template_utils.try_get_content(validation, 'mandatory', default=False)
+    }
+
+    if field_type == 'enum':
+      options = template_utils.try_get_content(validation, 'options')
+      if options:
+        field_data['field_inputs'] = [
+          { 'id': key, 'value': value } for key, value in options.items()
+        ]
+
+    formatted_fields.append(field_data)
+  
+  return Response(
+    data={
+      'id': template.id,
+      'version_id': template.template_version,
+      'template': formatted_fields
+    },
+    status=status.HTTP_200_OK
+  )

--- a/CodeListLibrary_project/clinicalcode/entity_utils/api_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/api_utils.py
@@ -445,9 +445,23 @@ def get_codelist_from_entity(entity):
     status=status.HTTP_200_OK
   )
 
+def populate_entity_version_id(form):
+  form_entity = form.get('entity')
+  if form_entity is not None:
+    form['entity']['version_id'] = None
+
+    entity = GenericEntity.objects.get(id=form_entity['id'])
+    if entity is not None:
+      historical_version = entity.history.all().order_by('-history_id')
+      historical_version = historical_version.first()
+      form['entity']['version_id'] = historical_version.history_id
+
+  return form
+
 def validate_api_create_update_form(request, method):
   form_errors = []
   form = gen_utils.get_request_body(request)
+  form = populate_entity_version_id(form)
   form = create_utils.validate_entity_form(
     request, form, form_errors, method=method
   )

--- a/CodeListLibrary_project/clinicalcode/entity_utils/constants.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/constants.py
@@ -184,6 +184,13 @@ API_HIDDEN_FIELDS = [
 ]
 
 '''
+    Re-maps field names to user readable field names
+'''
+API_MAP_FIELD_NAMES = {
+    'id': 'phenotype_id'
+}
+
+'''
     Describes fields that should be stripped from entity list api response
 '''
 ENTITY_LIST_API_HIDDEN_FIELDS = [

--- a/CodeListLibrary_project/clinicalcode/entity_utils/create_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/create_utils.py
@@ -234,7 +234,7 @@ def validate_form_entity(form_entity, form_method, errors=[], default=None):
         return default
 
     entity_id = form_entity.get('id')
-    history_id = gen_utils.parse_int(form_entity.get('history_id'), None)
+    history_id = gen_utils.parse_int(form_entity.get('version_id'), None)
     if not entity_id or not history_id:
         errors.append('Form entity is invalid, unable to find either the ID or the entity history ID')
         return default

--- a/CodeListLibrary_project/clinicalcode/entity_utils/gen_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/gen_utils.py
@@ -168,6 +168,9 @@ def try_value_as_type(field_value, field_type, validation=None, default=None):
                 return default
         return parse_int(field_value, default)
     elif field_type == 'int_array':
+        if isinstance(field_value, int):
+            return [field_value]
+        
         if not isinstance(field_value, list):
             return default
         
@@ -201,6 +204,9 @@ def try_value_as_type(field_value, field_type, validation=None, default=None):
         else:
             return value
     elif field_type == 'string_array':
+        if isinstance(field_value, str):
+            return [field_value]
+        
         if not isinstance(field_value, list):
             return default
         

--- a/CodeListLibrary_project/clinicalcode/entity_utils/model_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/model_utils.py
@@ -751,7 +751,7 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
   
   result = {
     'concept_id': concept_id,
-    'concept_history_id': concept_history_id,
+    'concept_version_id': concept_history_id,
     'coding_system': get_coding_system_details(historical_concept.coding_system),
     'details': concept_data,
     'components': components_data.get('components'),

--- a/CodeListLibrary_project/clinicalcode/views/adminTemp.py
+++ b/CodeListLibrary_project/clinicalcode/views/adminTemp.py
@@ -828,7 +828,7 @@ def admin_mig_phenotypes_dt(request):
                             cursor.execute(sql_p)
                     
                     with connection.cursor() as cursor:
-                        sql_entity_count = "update clinicalcode_entityclass set entity_count ="+str(live_pheno_count)+";"
+                        sql_entity_count = "update clinicalcode_entityclass set entity_count ="+str(live_pheno_count)+" where id = 1;"
                         cursor.execute(sql_entity_count)
 
                     historical_pheno = Phenotype.history.filter(~Q(id='x'))

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/clinical/conceptCreator.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/clinical/conceptCreator.js
@@ -375,7 +375,7 @@ export default class ConceptCreator {
     this.dirty = true;
 
     if (!isNullOrUndefined(id) && !isNullOrUndefined(historyId)) {
-      const concept = this.data.find(item => item.concept_id == id && item.concept_history_id == historyId);
+      const concept = this.data.find(item => item.concept_id == id && item.concept_version_id == historyId);
       if (!isNullOrUndefined(concept)) {
         concept.is_dirty = true;
       }
@@ -539,7 +539,7 @@ export default class ConceptCreator {
       this.state.data = null;
 
       // Remove unaltered, new component if not saved to data
-      const obj = this.data.find(item => item.concept_id == id && item.concept_history_id == history_id);
+      const obj = this.data.find(item => item.concept_id == id && item.concept_version_id == history_id);
       if (!obj) {
         element.remove();
         this.#toggleNoConceptBox(this.data.length > 0);
@@ -740,7 +740,7 @@ export default class ConceptCreator {
     const container = conceptGroup.querySelector('#concept-codelist-table');
     if (item.classList.contains('is-open')) {
       // Render codelist
-      let dataset = this.data.filter(concept => concept.concept_history_id == historyId && concept.concept_id == conceptId);
+      let dataset = this.data.filter(concept => concept.concept_version_id == historyId && concept.concept_id == conceptId);
       dataset = deepCopy(dataset.shift());
 
       return this.#tryRenderCodelist(container, dataset);
@@ -790,7 +790,7 @@ export default class ConceptCreator {
     const html = interpolateHTML(template, {
       'concept_name': concept?.details?.name,
       'concept_id': concept?.concept_id,
-      'concept_history_id': concept?.concept_history_id,
+      'concept_version_id': concept?.concept_version_id,
       'coding_id': concept?.coding_system?.id,
       'coding_system': concept?.coding_system?.description,
     });
@@ -1585,7 +1585,7 @@ export default class ConceptCreator {
     this.state.data = null;
     
     // Create or update the concept given the editor data
-    let index = this.data.findIndex(item => item.concept_id == data.concept_id && item.concept_history_id == data.concept_history_id);
+    let index = this.data.findIndex(item => item.concept_id == data.concept_id && item.concept_version_id == data.concept_version_id);
     let isNew = index < 0;
     if (isNew) {
       this.data.push(data);
@@ -1594,10 +1594,10 @@ export default class ConceptCreator {
     }
 
     // Reset the interface
-    this.#tryUpdateRenderConceptComponents(data.concept_id, data.concept_history_id);
+    this.#tryUpdateRenderConceptComponents(data.concept_id, data.concept_version_id);
 
     // Inform the parent form we're dirty
-    this.makeDirty(data?.concept_id, data?.concept_history_id);
+    this.makeDirty(data?.concept_id, data?.concept_version_id);
   }
   
   /**
@@ -1611,7 +1611,7 @@ export default class ConceptCreator {
         const concept = {
           is_new: true,
           concept_id: generateUUID(),
-          concept_history_id: generateUUID(),
+          concept_version_id: generateUUID(),
           components: [ ],
           aggregated_component_codes: [ ],
           details: {
@@ -1646,7 +1646,7 @@ export default class ConceptCreator {
         }
 
         // Render the editor
-        let dataset = this.data.filter(concept => concept.concept_history_id == historyId && concept.concept_id == conceptId);
+        let dataset = this.data.filter(concept => concept.concept_version_id == historyId && concept.concept_id == conceptId);
         dataset = deepCopy(dataset.shift());
 
         this.#tryRenderEditor(conceptGroup, dataset);
@@ -1677,7 +1677,7 @@ export default class ConceptCreator {
       const historyId = conceptGroup.getAttribute('data-concept-history-id');
 
       // Remove if it's a concept that's in our dataset
-      const index = this.data.findIndex(item => item.concept_id == conceptId && item.concept_history_id == historyId);
+      const index = this.data.findIndex(item => item.concept_id == conceptId && item.concept_version_id == historyId);
       if (index < 0) {
         return;
       }

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/entityCreator.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/entityCreator.js
@@ -1005,7 +1005,7 @@ class EntityCreator {
 
     if (this.data?.object) {
       const { id, history_id } = this.data.object;
-      packet.entity = { id: id, history_id: history_id };
+      packet.entity = { id: id, version_id: history_id };
     }
 
     if (this.data?.template) {

--- a/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
+++ b/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
@@ -27,7 +27,7 @@
   </section>
 
   <template id="concept-item">
-    <section class="concept-list__group" data-concept-id="${concept_id}" data-concept-history-id="${concept_history_id}">
+    <section class="concept-list__group" data-concept-id="${concept_id}" data-concept-history-id="${concept_version_id}">
       <span class="concept-list__group-item" id="concept-accordian-header">
         <span class="contextual-icon" tabindex="0" aria-label="Expand Concept" role="button" data-target="is-open"></span>
         <span class="concept-name" tabindex="0" aria-label="Expand Concept" role="button" data-target="is-open">${concept_name}</span>


### PR DESCRIPTION
Related work:
 - https://github.com/SwanseaUniversityMedical/concept-library/pull/1101
 - https://github.com/SwanseaUniversityMedical/concept-library/pull/1084
 - https://github.com/SwanseaUniversityMedical/concept-library/pull/1077
 - https://github.com/SwanseaUniversityMedical/concept-library/pull/1075

Related task:
- https://github.com/SwanseaUniversityMedical/concept-library/issues/1134
- https://github.com/SwanseaUniversityMedical/concept-library/issues/1135

Tasks:
- [x] Filtering phenotypes by template and template version in phenotypes/ endpoint
- [x] API endpoints for templates incl. templates/, template/{id}/detail, template/{id}/get-versions
- [x] Concepts build correctly from API -> R package
- [x] Fix concept_version_id error in all effected files
- [x] Match API endpoints to previous functionality (e.g. public/ modifier & switching over to phenotypes/ endpoint)
- [x] Uploading different template versions
- [X] Works with Working Set
- [x] Based on feedback, assoc. version_id on template update should be done on the server rather than the client (i.e. version_id from user should be ignored through API)
- [x] Show latest version to authenticated user regardless of publication status

Remaining tasks relate to R package and will be referenced in a separate issue