### PR TITLE
some fixes to permission functions

### DIFF
--- a/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
+++ b/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
@@ -288,8 +288,8 @@ def get_entity_detail(request, primary_key, historical_id=None, field=None):
     historical_entity = historical_entity_response
 
     # Check if the user has the permissions to view this entity version
-    user_can_access = permission_utils.has_entity_view_permissions(
-        request, historical_entity
+    user_can_access = permission_utils.can_user_view_entity(
+        request, historical_entity.id, historical_entity.history_id
     )
     if not user_can_access:
         return Response(

--- a/CodeListLibrary_project/clinicalcode/entity_utils/api_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/api_utils.py
@@ -95,7 +95,7 @@ def get_entity_version_history(request, entity_id):
       version, [permission_utils.APPROVAL_STATUS.APPROVED]
     )
 
-    if permission_utils.has_entity_view_permissions(request, version):
+    if permission_utils.can_user_view_entity(request, version.id, version.history_id):
       result.append({
         'version_id': version.history_id,
         'version_name': version.name.encode('ascii', 'ignore').decode('ascii'),

--- a/CodeListLibrary_project/clinicalcode/entity_utils/model_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/model_utils.py
@@ -18,7 +18,8 @@ from ..models.CodeList import CodeList
 from ..models.ConceptCodeAttribute import ConceptCodeAttribute
 from ..models.Code import Code
 from .constants import (USERDATA_MODELS, STRIPPED_FIELDS, APPROVAL_STATUS,
-                        GROUP_PERMISSIONS, TAG_TYPE, HISTORICAL_HIDDEN_FIELDS,
+                        GROUP_PERMISSIONS, WORLD_ACCESS_PERMISSIONS,
+                        TAG_TYPE, HISTORICAL_HIDDEN_FIELDS,
                         CLINICAL_RULE_TYPE, CLINICAL_CODE_SOURCE)
 
 def try_get_instance(model, **kwargs):
@@ -96,6 +97,9 @@ def get_latest_entity_historical_id(entity_id, user):
         Q(
           group_id__in=user.groups.all(),
           group_access__in=[GROUP_PERMISSIONS.VIEW, GROUP_PERMISSIONS.EDIT]
+        ) |
+        Q(
+          world_access=WORLD_ACCESS_PERMISSIONS.VIEW
         )
       ) \
       .order_by('-history_id')


### PR DESCRIPTION
I renamed permission_utils.has_entity_view_permissions() to permission_utils.can_user_view_entity(), with change to input param made changes so permission is always checked on the live version, as agreed world_access check is now added.
also added checks for brand, so when in a brand only show this brand's data unless it is published.