### PR TITLE
Concept Importing via Phenotype Builder

### DIFF
--- a/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
+++ b/CodeListLibrary_project/clinicalcode/api/views/GenericEntity.py
@@ -192,7 +192,7 @@ def get_generic_entities(request, should_paginate=False):
     # Build query from searchable GenericEntity template fields
     templates = Template.objects.all()
     for template in templates:
-        merged_definition = template_utils.get_merged_definition(template)
+        merged_definition = template_utils.get_merged_definition(template, default={})
         template_fields = template_utils.try_get_content(merged_definition, 'fields')
 
         template_query, where_clause = api_utils.build_query_from_template(

--- a/CodeListLibrary_project/clinicalcode/api/views/Template.py
+++ b/CodeListLibrary_project/clinicalcode/api/views/Template.py
@@ -114,7 +114,7 @@ def get_template(request, template_id, version_id=None):
         )
     template = template.latest()
     
-  merged_definition = template_utils.get_merged_definition(template)
+  merged_definition = template_utils.get_merged_definition(template, default={})
   template_fields = template_utils.try_get_content(merged_definition, 'fields')
   
   formatted_fields = []

--- a/CodeListLibrary_project/clinicalcode/entity_utils/api_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/api_utils.py
@@ -524,7 +524,7 @@ def get_entity_detail(
     return layout_response
   
   layout = layout_response
-  layout_definition = template_utils.get_merged_definition(layout)
+  layout_definition = template_utils.get_merged_definition(layout, default={})
   layout_version = layout.template_version
 
   fields = template_utils.try_get_content(layout_definition, 'fields')

--- a/CodeListLibrary_project/clinicalcode/entity_utils/constants.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/constants.py
@@ -48,6 +48,7 @@ class CLINICAL_CODE_SOURCE(int, enum.Enum, metaclass=IterableMeta):
     SELECT_IMPORT = 4
     FILE_IMPORT = 5
     SEARCH_TERM = 6
+    CONCEPT_IMPORT = 7
 
 class ENTITY_STATUS(int, enum.Enum):
     '''

--- a/CodeListLibrary_project/clinicalcode/entity_utils/create_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/create_utils.py
@@ -45,7 +45,7 @@ def get_createable_entities(request):
         'templates': list(templates)
     }
 
-def get_template_creation_data(request, entity, layout, field, default=[]):
+def get_template_creation_data(request, entity, layout, field, default=None):
     '''
         Used to retrieve assoc. data values for specific keys, e.g.
         concepts, in its expanded format for use with create/update pages

--- a/CodeListLibrary_project/clinicalcode/entity_utils/gen_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/gen_utils.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.http.response import JsonResponse
+from django.core.exceptions import BadRequest
 from django.http.multipartparser import MultiPartParser
+from django.utils.timezone import make_aware
 from functools import wraps
-from dateutil import parser
+from dateutil import parser as dateparser
 from json import JSONEncoder
 
 import re
@@ -85,6 +87,22 @@ def is_fetch_request(request):
     '''
     return request.headers.get('X-Requested-With') == constants.FETCH_REQUEST_HEADER
 
+def handle_fetch_request(request, obj, *args, **kwargs):
+    '''
+        @desc Parses the X-Target header to determine which GET method
+              to respond with
+    '''
+    target = request.headers.get('X-Target', None)
+    if target is None or target not in obj.fetch_methods:
+        raise BadRequest('No such target')
+    
+    try:
+        response = getattr(obj, target)
+    except Exception as e:
+        raise BadRequest('Invalid request')
+    else:
+        return response 
+
 def decode_uri_parameter(value, default=None):
     '''
         Decodes an ecoded URI parameter e.g. 'wildcard:C\d+' encoded as 'wildcard%3AC%5Cd%2B'
@@ -146,16 +164,32 @@ def parse_int(value, default=0):
     else:
         return value
 
+def get_start_and_end_dates(daterange):
+    '''
+        Sorts a date range to [min, max] and sets their timepoints to the [start] and [end] of the day respectively
+
+        Args:
+            daterange {list[string]}: List of dates as strings (size of 2)
+        
+        Returns:
+            A sorted {list} of datetime objects, combined with their respective start and end times
+    '''
+    dates = [dateparser.parse(x).date() for x in daterange]
+    
+    max_date = datetime.datetime.combine(max(dates), datetime.time(23, 59, 59, 999))
+    min_date = datetime.datetime.combine(min(dates), datetime.time(00, 00, 00, 000))
+    return [min_date, max_date]
+
 def parse_date(value, default=0):
     '''
         Attempts to parse a date from a string value, if it fails to do so, returns the default value
     '''
     try:
-        date = parser.parse(value)
+        date = dateparser.parse(value)
     except:
         return default
     else:
-        return date.strftime('%Y-%m-%d')
+        return date.strftime('%Y-%m-%d %H:%M:%S')
 
 def parse_as_int_list(value):
     result = []

--- a/CodeListLibrary_project/clinicalcode/entity_utils/search_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/search_utils.py
@@ -98,7 +98,7 @@ def get_metadata_filters(request):
             options = get_metadata_stats_by_field(field, brand=current_brand)
 
         if options is None and 'source' in validation:
-            options = get_source_references(packet)
+            options = get_source_references(packet, default=[])
         
         filters.append({
             'details': details,
@@ -643,7 +643,7 @@ def try_get_paginated_results(request, entities, page=None, page_size=None):
         page_obj = pagination.page(pagination.num_pages)
     return page_obj
 
-def get_source_references(struct, default=[], modifier=None):
+def get_source_references(struct, default=None, modifier=None):
     '''
         Retrieves the refence values from source fields e.g. tags, collections, entity type
     '''

--- a/CodeListLibrary_project/clinicalcode/entity_utils/template_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/template_utils.py
@@ -1,6 +1,5 @@
 from django.apps import apps
 from django.db.models import Q, ForeignKey
-from django.contrib.auth.models import User, Group
 
 from . import filter_utils
 from . import concept_utils
@@ -46,9 +45,15 @@ def is_layout_safe(layout):
         return False
 
     definition = try_get_content(layout, 'definition') if isinstance(layout, dict) else getattr(layout, 'definition')
-    if layout is None:
-        return False
     return isinstance(definition, dict)
+
+def try_get_layout(template, default=None):
+    '''
+        Tries to get the definition from a template
+    '''
+    if not is_layout_safe(template):
+        return default
+    return try_get_content(template, 'definition') if isinstance(template, dict) else getattr(template, 'definition')
 
 def is_data_safe(entity):
     '''

--- a/CodeListLibrary_project/clinicalcode/entity_utils/template_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/template_utils.py
@@ -84,7 +84,7 @@ def get_layout_field(layout, field, default=None):
     
     return try_get_content(layout, field, default)
 
-def get_merged_definition(template, default={}):
+def get_merged_definition(template, default=None):
     '''
         Used to merge the metadata into a template such that interfaces, e.g. API/create,
         can understand the origin of fields
@@ -529,7 +529,7 @@ def get_sourced_value(data, info, default=None):
     except:
         return default
 
-def get_template_data_values(entity, layout, field, hide_user_details=False, default=[]):
+def get_template_data_values(entity, layout, field, hide_user_details=False, default=None):
     '''
         Retrieves the sourced values from an entity in an array
     '''

--- a/CodeListLibrary_project/clinicalcode/templatetags/detail_pg_renderer.py
+++ b/CodeListLibrary_project/clinicalcode/templatetags/detail_pg_renderer.py
@@ -214,7 +214,7 @@ def get_data_sources(ds_ids, info, default=None):
     except:
         return default
     
-def get_template_creation_data(entity, layout, field, default=[]):
+def get_template_creation_data(entity, layout, field, default=None):
     '''
         Used to retrieve assoc. data values for specific keys, e.g.
         concepts, in its expanded format for use with create/update pages
@@ -305,7 +305,7 @@ class EntityWizardSections(template.Node):
         if template is None:
             return output
         
-        merged_definition = template_utils.get_merged_definition(template)
+        merged_definition = template_utils.get_merged_definition(template, default={})
         template_fields = template_utils.try_get_content(merged_definition, 'fields')
         template_fields.update(constants.DETAIL_PAGE_APPENDED_FIELDS)
         template.definition['fields'] = template_fields

--- a/CodeListLibrary_project/clinicalcode/templatetags/entity_renderer.py
+++ b/CodeListLibrary_project/clinicalcode/templatetags/entity_renderer.py
@@ -229,7 +229,7 @@ def renderable_field_values(entity, layout, field):
         # handle metadata e.g. collections, tags etc
         return template_utils.get_metadata_value_from_source(entity, field, default=[])
     
-    return template_utils.get_template_data_values(entity, layout, field)
+    return template_utils.get_template_data_values(entity, layout, field, default=[])
 
 @register.tag(name='render_entity_cards')
 def render_entities(parser, token):
@@ -329,7 +329,7 @@ class EntityFiltersNode(template.Node):
         else:
             modifier = None
 
-        return search_utils.get_source_references(structure, modifier=modifier)
+        return search_utils.get_source_references(structure, default=[], modifier=modifier)
 
     def __render_metadata_component(self, context, field, structure):
         '''

--- a/CodeListLibrary_project/clinicalcode/urls_generic_entity.py
+++ b/CodeListLibrary_project/clinicalcode/urls_generic_entity.py
@@ -1,31 +1,24 @@
 '''
     URL Configuration for the Generic Entity.
 '''
-
 from django.conf import settings
 from django.urls import re_path as url
 from django.contrib.auth import views as auth_views
+from django.views.generic.base import TemplateView
 
 from .views import (GenericEntity, adminTemp, Profile, Moderation)
 from clinicalcode.views import Publish
 from clinicalcode.views import Decline
 
-from django.urls import path
-from django.views.generic.base import TemplateView
-
-#from django.views.generic import RedirectView
-#from django.urls import reverse_lazy, reverse
-
 urlpatterns = []
- 
  
 if settings.IS_DEMO or settings.IS_DEVELOPMENT_PC:
     urlpatterns += [  
-
+        # Search
         url(r'^phenotypes/$', GenericEntity.EntitySearchView.as_view(), name='search_phenotypes'),
         url(r'^phenotypes/(?P<entity_type>([A-Za-z0-9\-]+))/?$', GenericEntity.EntitySearchView.as_view(), name='search_phenotypes'),
         
-
+        # Detail
         url(r'^phenotypes/(?P<pk>\w+)/detail/$', GenericEntity.generic_entity_detail, name='entity_detail'),
         url(r'^phenotypes/(?P<pk>\w+)/version/(?P<history_id>\d+)/detail/$', GenericEntity.generic_entity_detail, name='entity_history_detail'),
 
@@ -39,27 +32,25 @@ if settings.IS_DEMO or settings.IS_DEVELOPMENT_PC:
         # Profile
         url(r'profile/$', Profile.MyProfile.as_view(), name='my_profile'),
         url(r'profile/collection/$', Profile.MyCollection.as_view(), name='my_collection'),
+        url(r'moderation/$', Moderation.EntityModeration.as_view(), name='moderation_page'),
 
-        url(r'moderation/$', Moderation.EntityModeration.as_view(), name='moderation_page'),        
+        # Selection service(s)
+        url(r'^query/(?P<template_id>\w+)/?$', GenericEntity.EntityDescendantSelection.as_view(), name='entity_descendants'),
 
         # Example - remove at production
         url(r'^ge/example/$', GenericEntity.ExampleSASSView.as_view(), name='example_phenotype'),
         url(r'^ge/search/temp/$', GenericEntity.generic_entity_list_temp, name='generic_entity_list_temp'),
-
-
     ]
 
-
-
-
-    # for create/update - not to work in Read-only mode
+    # For create/update/publish - blocked in Read-only mode
     if not settings.CLL_READ_ONLY:
         urlpatterns += [
+            # Create / Update
             url(r'^create/$', GenericEntity.CreateEntityView.as_view(), name='create_phenotype'),
             url(r'^create/(?P<template_id>[\d]+)/?$', GenericEntity.CreateEntityView.as_view(), name='create_phenotype'),
             url(r'^update/(?P<entity_id>\w+)/(?P<entity_history_id>\d+)/?$', GenericEntity.CreateEntityView.as_view(), name='update_phenotype'),
 
-            # publish
+            # Public 
             url(r'^phenotypes/(?P<pk>\w+)/(?P<history_id>\d+)/publish/$',Publish.Publish.as_view(),name='generic_entity_publish'),
             url(r'^phenotypes/(?P<pk>\w+)/(?P<history_id>\d+)/decline/$',Decline.EntityDecline.as_view(),name='generic_entity_decline'),
             url(r'^phenotypes/(?P<pk>\w+)/(?P<history_id>\d+)/submit/$',Publish.RequestPublish.as_view(),name='generic_entity_request_publish'),

--- a/CodeListLibrary_project/clinicalcode/urls_generic_entity.py
+++ b/CodeListLibrary_project/clinicalcode/urls_generic_entity.py
@@ -50,7 +50,7 @@ if settings.IS_DEMO or settings.IS_DEVELOPMENT_PC:
             url(r'^create/(?P<template_id>[\d]+)/?$', GenericEntity.CreateEntityView.as_view(), name='create_phenotype'),
             url(r'^update/(?P<entity_id>\w+)/(?P<entity_history_id>\d+)/?$', GenericEntity.CreateEntityView.as_view(), name='update_phenotype'),
 
-            # Public 
+            # Publication
             url(r'^phenotypes/(?P<pk>\w+)/(?P<history_id>\d+)/publish/$',Publish.Publish.as_view(),name='generic_entity_publish'),
             url(r'^phenotypes/(?P<pk>\w+)/(?P<history_id>\d+)/decline/$',Decline.EntityDecline.as_view(),name='generic_entity_decline'),
             url(r'^phenotypes/(?P<pk>\w+)/(?P<history_id>\d+)/submit/$',Publish.RequestPublish.as_view(),name='generic_entity_request_publish'),

--- a/CodeListLibrary_project/cll/static/cookielaw/css/cookiealert.css
+++ b/CodeListLibrary_project/cll/static/cookielaw/css/cookiealert.css
@@ -1,56 +1,48 @@
-
 .cookiealert {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    z-index: 999;
-    opacity: 0;
-    visibility: hidden;
-    border-radius: 0;
-    transform: translateY(100%);
-    color: #ecf0f1;
-    background: rgba(0, 0, 0, .85) !important;
-    padding: 20px;
-    margin: 0 !important;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  z-index: 999;
+  opacity: 0;
+  visibility: hidden;
+  border-radius: 0;
+  transform: translateY(100%);
+  color: #ecf0f1;
+  background: rgba(0, 0, 0, .85) !important;
+  padding: 20px;
+  margin: 0 !important;
 }
 
 .cookiealert.show {
-    opacity: 1;
-    visibility: visible;
-    transform: translateY(0%);
-    transition: all 300ms ease-out;
-    
-    
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0%);
+  transition: all 300ms ease-out;
 }
 
 .cookiealert a {
-    text-decoration: underline
+  text-decoration: underline;
 }
 
 .cookie_buttons{
-    display: inline-flex;
-    
-    
-    margin-left: 30px;
-    margin-right: 10px;
-    
-    justify-content: flex-end;
-    flex-wrap: wrap;
-    flex-direction: row;
+  display: inline-flex;
+  margin-left: 30px;
+  margin-right: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  flex-direction: row;
 }
 
-
 .cookiealert .acceptcookies, .rejectcookies, .preferencecookies {
-    margin-left: 15px;
-    vertical-align: baseline;
-    
+  margin-left: 15px;
+  vertical-align: baseline;
 }
 
 .btn.acceptcookies:hover, .btn.rejectcookies:hover{
-     background-color: #e7e7e7;
-     transition: all 500ms ease-out;
-     color: #000;
+  background-color: #e7e7e7;
+  transition: all 500ms ease-out;
+  color: #000;
 }
 
 .btn.acceptcookies,  .btn.rejectcookies{
@@ -59,19 +51,14 @@
   line-height: 30px;
   background: #18adca;
   font-size: 1.05em;
-  
-
   border-radius: 2px;
 }
 
 .btn.preferencecookies{
-    color: #ffffff;
-    
-    font-size: 14px;
-    width: fit-content;
-    text-align: center;
-    border-radius: 0em;
-    background-color:transparent;
+  color: #ffffff;
+  font-size: 14px;
+  width: fit-content;
+  text-align: center;
+  border-radius: 0em;
+  background-color:transparent;
 }
-
-

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/fuzzyQuery.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/fuzzyQuery.js
@@ -116,7 +116,8 @@ export default class FuzzyQuery {
    * @param {function} transformer The preprocessing function, per the FuzzyQuery.Transformers enum
    * @return {array} An array of matches
    */
-  static Search(haystack = [], query = '', sort = 1, transformer = null) {
+  static Search(haystack, query = '', sort = 1, transformer = null) {
+    haystack = haystack || [];
     query = String(query);
     sort = Boolean(sort);
 

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/groupedEnumSelector.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/groupedEnumSelector.js
@@ -79,7 +79,6 @@ export default class GroupedEnum {
     const inputs = this.element.querySelectorAll('input');
     for (let i = 0; i < inputs.length; ++i) {
       let val = inputs[i].getAttribute('data-value');
-      console.log(val, value);
       inputs[i].checked = val === value;
     }
 

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/modal.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/modal.js
@@ -168,7 +168,8 @@ class ModalFactory {
     this.modal = null;
   }
 
-  create(options = { }) {
+  create(options) {
+    options = options || { };
     this.closeCurrentModal();
 
     try {

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/modal.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/components/modal.js
@@ -29,7 +29,7 @@ const PROMPT_BUTTONS_DEFAULT = [
  * @desc Defines the default style of the modal container
  */
 const PROMPT_DEFAULT_CONTAINER = '\
-<div class="target-modal" id="${id}" aria-hidden="true"> \
+<div class="target-modal target-modal-${size}" id="${id}" aria-hidden="true"> \
   <div class="target-modal__container"> \
     <div class="target-modal__header"> \
       <h2 id="target-modal-title">${title}</h2> \
@@ -42,6 +42,16 @@ const PROMPT_DEFAULT_CONTAINER = '\
 </div>';
 
 /**
+ * PROMPT_MODAL_SIZES
+ * @desc Defines the sizes available for the modal prompt
+ */
+const PROMPT_MODAL_SIZES = {
+  Small: 'sm',
+  Medium: 'md',
+  Large: 'lg',
+};
+
+/**
  * PROMPT_DEFAULT_PARAMS
  * @desc Defines the default parameters for the modal
  */
@@ -50,6 +60,7 @@ const PROMPT_DEFAULT_PARAMS = {
   title: 'Modal',
   content: '',
   showFooter: true,
+  size: PROMPT_MODAL_SIZES.Medium,
   buttons: PROMPT_BUTTONS_DEFAULT,
 };
 
@@ -150,6 +161,7 @@ class ModalResult {
 class ModalFactory {
   ButtonTypes = PROMPT_BUTTON_TYPES;
   DefaultButtons = PROMPT_BUTTONS_DEFAULT;
+  ModalSizes = PROMPT_MODAL_SIZES;
   ModalResults = ModalResult;
 
   constructor() {
@@ -162,10 +174,11 @@ class ModalFactory {
     try {
       options = mergeObjects(options, PROMPT_DEFAULT_PARAMS);
 
-      const { id, title, content, showFooter, buttons } = options;
+      const { id, title, content, showFooter, buttons, size } = options;
     
-      const html = interpolateHTML(PROMPT_DEFAULT_CONTAINER, { id: id, title: title, content: content });
+      const html = interpolateHTML(PROMPT_DEFAULT_CONTAINER, { id: id, title: title, content: content, size: size });
       const doc = parseHTMLFromString(html);
+      const currentHeight = window.scrollY;
       const modal = document.body.appendChild(doc.body.children[0]);
       const container = modal.querySelector('.target-modal__container');
 
@@ -197,6 +210,8 @@ class ModalFactory {
       }
 
       const closeModal = (method, details) => {
+        document.body.classList.remove('modal-open');
+        window.scrollTo({ top: currentHeight, left: window.scrollX, behaviour: 'instant'});
         modal.remove();
         history.replaceState({ }, document.title, '#');
         this.modal = null;
@@ -238,7 +253,6 @@ class ModalFactory {
         }
         
         // Show the modal
-        const currentHeight = window.scrollY;
         createElement('a', { href: `#${id}` }).click();
         window.scrollTo({ top: currentHeight, left: window.scrollX, behaviour: 'instant'});
     
@@ -246,6 +260,9 @@ class ModalFactory {
         modal.setAttribute('aria-hidden', false);
         modal.setAttribute('role', 'alert');
         modal.setAttribute('aria-live', true);
+
+        // Stop scrolling on body when modal is open
+        document.body.classList.add('modal-open');
       });
 
       this.modal = {

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/data/conceptUtils.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/data/conceptUtils.js
@@ -21,8 +21,8 @@ const CONCEPT_UTILS_DEFAULT_ARGS = {
  * @param {object} options optional parameters to modify the behaviour of the method
  *                         see CONCEPT_UTILS_DEFAULT_ARGS.APPLICATOR for more details
  */
-const applyCodelistsFromConcepts = ( conceptData, options = {} ) => {
-  options = mergeObjects(options, CONCEPT_UTILS_DEFAULT_ARGS.APPLICATOR);
+const applyCodelistsFromConcepts = ( conceptData, options) => {
+  options = mergeObjects(options || { }, CONCEPT_UTILS_DEFAULT_ARGS.APPLICATOR);
 
   const { codelistContainerId, showAttributes, perPageSelect } = options;
   for (let ii = 0; ii < conceptData.length; ii++) {

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/clinical/conceptCreator.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/clinical/conceptCreator.js
@@ -1,4 +1,5 @@
 import { parse as parseCSV } from '../../vendor/csv.min.js';
+import { ConceptSelectionService } from '../../services/conceptSelectionService.js';
 
 /**
  * tryCleanCodingCSV
@@ -44,7 +45,7 @@ const tryCleanCodingItem = (val, row, col) => {
     return;
   }
   
-  return val.replace(/^\s+|\s+$/gm,'');
+  return val.replace(/^\s+|\s+$/gm, '');
 }
 
 /**
@@ -115,31 +116,43 @@ const CONCEPT_CREATOR_SOURCE_TYPES = {
     name: 'CONCEPT',
     value: 1,
     template: 'file-rule',
+    disabled: true,
   },
   QUERY_BUILDER: { 
     name: 'QUERY_BUILDER',
     value: 2,
     template: 'file-rule',
+    disabled: true,
   },
   EXPRESSION: {
     name: 'EXPRESSION',
     value: 3,
     template: 'file-rule',
+    disabled: true,
   },
   SELECT_IMPORT: {
     name: 'SELECT_IMPORT',
     value: 4,
     template: 'file-rule',
+    disabled: true,
   },
   FILE_IMPORT: {
     name: 'FILE_IMPORT',
     value: 5,
     template: 'file-rule',
+    disabled: true,
   },
   SEARCH_TERM: {
     name: 'SEARCH_TERM',
     value: 6,
     template: 'search-rule',
+    disabled: false,
+  },
+  CONCEPT_IMPORT: {
+    name: 'CONCEPT_IMPORT',
+    value: 7,
+    template: 'concept-rule',
+    disabled: true,
   },
 }
 
@@ -243,12 +256,24 @@ const CONCEPT_CREATOR_TEXT = {
   REQUIRE_CODING_SYSTEM: 'You need to select a coding system before saving!',
   // Toast to inform user that no code was matched
   NO_CODE_SEARCH_MATCH: 'No matches for "${value}..."',
+  // Toast to inform user we exchanged codes for a null match
+  NO_CODE_SEARCH_EXCHANGE: 'No matches for "${value}...", removed ${code_len} codes',
   // Toast to inform user that the search codes were added
   ADDED_SEARCH_CODES: 'Added ${code_len} codes for "${value}..."',
+  // Toast to inform user that the search codes were exchanged
+  EXCHANGED_SEARCH_CODES: 'Exchanged ${prev_code_len} codes for ${new_code_len} for "${value}..."',
   // Toast to inform the user that the codes from the uploaded files were added
   ADDED_FILE_CODES: 'Added ${code_len} codes via File Upload',
   // Toast to inform the user there was an error when trying to upload their code file
   NO_CODE_FILE_MATCH: 'Unable to parse uploaded file. Please try again.',
+  // Toast to inform the user that the codes from the imported concept(s) were added
+  ADDED_CONCEPT_CODES: 'Added ${code_len} codes via Concept Import',
+  // Toast to inform the user there was an error when trying to upload their code file
+  NO_CONCEPT_MATCH: 'We were unable to add this Concept. Please try again.',
+  // Toast to inform the user they tried to import non-distinct top-level concepts
+  CONCEPT_IMPORTS_ARE_PRESENT: 'Already imported ${failed}',
+  // Toast to inform the user they tried to import non-distinct rule-level concepts
+  CONCEPT_RULE_IS_PRESENT: 'You have already imported this Concept as a rule',
 }
 
 /**
@@ -427,6 +452,114 @@ export default class ConceptCreator {
    *                                   *
    *************************************/
   /**
+   * tryImportConcepts
+   * @desc prompts the user to import a Concept as a top-level object,
+   *       where the user can select 1 or more concepts to import
+   * @returns {promise} that can be used as a Thenable if required
+   */
+  tryImportConcepts() {
+    const prompt = new ConceptSelectionService({
+      promptTitle: 'Import Concepts',
+      template: this.template?.id,
+      allowMultiple: true
+    });
+
+    return prompt.show()
+      .then((data) => {
+        return this.#tryRetrieveCodelists(data);
+      });
+  }
+
+  /**
+   * tryPromptConceptRuleImport
+   * @desc tries to prompt the user to import a Concept as a rule,
+   *       where the user is only able to select a single concept
+   *       that relates to the coding system they're currently working within
+   * @returns {promise} a promise that resolves with a concept's data,
+   *                    otherwise rejects
+   */
+  tryPromptConceptRuleImport() {
+    const codingSystem = this.state.data.coding_system;
+    if (isNullOrUndefined(codingSystem)) {
+      return Promise.reject();
+    }
+
+    const { id: codingSystemId, name: codingSystemName } = codingSystem;
+    if (isNullOrUndefined(codingSystemId) || isNullOrUndefined(codingSystemName)) {
+      return Promise.reject();
+    }
+
+    const prompt = new ConceptSelectionService({
+      promptTitle: `Import Concept as Rule (${codingSystemName})`,
+      template: this.template?.id,
+      allowMultiple: false,
+      ignoreFilters: ['coding_system'],
+      forceFilters: {
+        coding_system: codingSystemId,
+      },
+    });
+
+    return prompt.show()
+      .then((data) => {
+        return this.#tryRetrieveRuleCodelist(data);
+      });
+  }
+
+  /**
+   * tryRetrieveRuleCodelist
+   * @desc retrieves the Concept's codelist from the endpoint
+   * @param {object} concept the concept to retrieve
+   * @returns {object} the retrieved concept
+   */
+  #tryRetrieveRuleCodelist(concept) {
+    const parameters = new URLSearchParams({
+      template: this.template?.id,
+      concept_id: concept.id,
+      concept_version_id: concept.history_id,
+    });
+
+    return fetch(
+      `${getCurrentURL()}?` + parameters,
+      {
+        method: 'GET',
+        headers: {
+          'X-Target': 'import_rule',
+          'X-Requested-With': 'XMLHttpRequest',
+        }
+      }
+    )
+    .then(response => response.json());
+  }
+
+  /**
+   * tryRetrieveCodelists
+   * @param {list[object]} concepts of type [ {id: [int], history_id: [int] } ]
+   * @returns {list[object]} of type [ {concept_id: [int], history_id: [int], codelist: [list] }]
+   */
+  #tryRetrieveCodelists(concepts) {
+    const ids = concepts.map(item => item.id);
+    const versions = concepts.map(item => item.history_id);
+    const parameters = new URLSearchParams({
+      template: this.template?.id,
+      concept_ids: ids.join(','),
+      concept_version_ids: versions.join(','),
+    });
+
+    return fetch(
+      `${getCurrentURL()}?` + parameters,
+      {
+        method: 'GET',
+        headers: {
+          'X-Target': 'import_concept',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      }
+    )
+    .then(response => response.json())
+    .then(response => response.concepts);
+  }
+
+  /**
    * tryPromptFileUpload
    * @desc tries to open a file prompt, allowing the user to select the file as defined by
    *       ConceptCreator's const defaults
@@ -454,7 +587,7 @@ export default class ConceptCreator {
           }
         }
       });
-    })
+    });
   }
 
   /**
@@ -516,7 +649,7 @@ export default class ConceptCreator {
         }
       }
     )
-    .then(response => response.json())
+    .then(response => response.json());
   }
 
   /**
@@ -533,8 +666,8 @@ export default class ConceptCreator {
     // Prompt user to det. whether they want to close the editor despite losing progress
     return new Promise((resolve, reject) => {
       window.ModalFactory.create(CONCEPT_CREATOR_TEXT.CLOSE_EDITOR)
-      .then(resolve)
-      .catch(reject);
+        .then(resolve)
+        .catch(reject);
     })
     .then(() => {
       const { id, history_id } = this.state.editing;
@@ -616,8 +749,12 @@ export default class ConceptCreator {
       }
     }
 
+    // Set up assoc. top-level button(s)
     const createBtn = this.element.querySelector('#create-concept-btn');
     createBtn.addEventListener('click', this.#handleConceptCreation.bind(this));
+
+    const importBtn = this.element.querySelector('#import-concept-btn');
+    importBtn.addEventListener('click', this.#handleConceptImporting.bind(this));
   }
 
   /*************************************
@@ -625,6 +762,71 @@ export default class ConceptCreator {
    *              Private              *
    *                                   *
    *************************************/
+  /**
+   * generateConceptRuleSource
+   * @desc generates the rule source name for a given concept
+   * @param {object} data the concept data returned from the prompt
+   * @returns {string} the source name
+   */
+  #generateConceptRuleSource(data) {
+    return `C${data.concept_id}/${data.concept_version_id}`;
+  }
+
+  /**
+   * getImportedName
+   * @desc modifies the concept's name to include its origin as a prefix
+   * @param {object} data the concept data
+   * @returns {string} the modified name
+   */
+  #getImportedName(data) {
+    const name = data.details.name;
+    const { concept_id: id, concept_version_id: history_id } = data;
+    return `C${id}/${history_id} - ${name}`;
+  }
+
+  /**
+   * isConceptRuleImportDistinct
+   * @desc ensures that the concept, imported as a rule in this case,
+   *       is distinct for its logical type
+   * @param {object} result the imported concept
+   * @param {string} logicalType the logical type of the rule i.e. include/exclude
+   * @returns {boolean} that reflects its uniqueness
+   */
+  #isConceptRuleImportDistinct(result, logicalType) {
+    const components = this.state.data?.components;
+    if (isNullOrUndefined(components)) {
+      return true;
+    }
+
+    const source = this.#generateConceptRuleSource(result);
+    const index = components?.findIndex(item => item?.source == source && item?.logical_type == logicalType);
+    return index < 0;
+  }
+
+  /**
+   * isConceptImportDistinct
+   * @desc ensures that the concept, imported as a top-level object in this case,
+   *       is distinct
+   * @param {object} result the imported concept
+   * @returns {boolean} that reflects its uniqueness
+   */
+  #isConceptImportDistinct(result) {
+    const index = this.data.findIndex(item => item?.concept_id == result?.concept_id && item.concept_version_id == result?.concept_version_id);
+    return index < 0;
+  }
+
+  /**
+   * deriveEditAccess
+   * @desc derives edit access (whether to render the edit button)
+   * @param {object} concept the concept to consider
+   * @returns {boolean} reflects edit access
+   */
+  #deriveEditAccess(concept) {
+    const canEdit = !isNullOrUndefined(concept?.details?.has_edit_access) ? concept?.details?.has_edit_access : false;
+    const isImported = concept?.imported;
+    return canEdit && !isImported;
+  }
+
   /**
    * getNextRuleCount
    * @desc gets n+1 of current rules
@@ -817,13 +1019,15 @@ export default class ConceptCreator {
    */
   #tryRenderConceptComponent(concept) {
     const template = this.templates['concept-item'];
+    const access = this.#deriveEditAccess(concept);
     const html = interpolateHTML(template, {
-      'concept_name': concept?.details?.name,
+      'concept_name': access ? concept?.details?.name : this.#getImportedName(concept),
       'concept_id': concept?.concept_id,
       'concept_version_id': concept?.concept_version_id,
       'coding_id': concept?.coding_system?.id,
       'coding_system': concept?.coding_system?.description,
-      'can_edit': concept?.details?.has_edit_access,
+      'can_edit': access,
+      'subheader': access ? 'Codelist' : 'Imported Codelist',
     });
 
     const containerList = this.element.querySelector('#concept-content-list');
@@ -1083,11 +1287,11 @@ export default class ConceptCreator {
     const checkbox = item.querySelector('.fill-accordian__input');
 
     // Add handler for each rule type, otherwise disable element
-    if (sourceInfo.template == 'file-rule') {
+    if (sourceInfo.disabled) {
       input.disabled = true;
     } else {
       // Open those that are still unused
-      if (!isNullOrUndefined(source)) {
+      if (isNullOrUndefined(source)) {
         checkbox.checked = true;
       }
 
@@ -1367,6 +1571,13 @@ export default class ConceptCreator {
         rule.codes = data?.content?.data;
       } break;
 
+      case 'concept-rule': {
+        const ruleSource = this.#generateConceptRuleSource(data);
+        rule.name = `Imported from ${ruleSource}`
+        rule.source = ruleSource;
+        rule.codes = data?.codelist;
+      } break;
+
       default: break;
     }
 
@@ -1516,35 +1727,74 @@ export default class ConceptCreator {
           });
 
           // Update row
+          const prevCodeLength = this.state.data.components?.[index]?.codes?.length;
           this.state.data.components[index].codes = codes.length > 0 ? codes : [ ];
           this.state.data.components[index].source = codes.length > 0 ? value : null;
           
+          // Blur the input focus
+          input.blur();
+
           // Apply changes and recompute codelist
           this.#tryRenderAggregatedCodelist();
           this.#computeAggregatedCodelist();
 
-          // Inform of null results
+          // Inform of null results (and inform of code loss if a prev. match was a success)
           if (codes.length < 1) {
+            if (prevCodeLength) {
+              this.#pushToast({
+                type: 'danger',
+                message: interpolateHTML(
+                  CONCEPT_CREATOR_TEXT.NO_CODE_SEARCH_EXCHANGE,
+                  {
+                    value: value.substring(0, CONCEPT_CREATOR_LIMITS.STRING_TRUNCATE),
+                    code_len: prevCodeLength,
+                  }
+                )
+              });
+
+              return;
+            }
+
             this.#pushToast({
               type: 'danger',
-              message: interpolateHTML(CONCEPT_CREATOR_TEXT.NO_CODE_SEARCH_MATCH, {
-                value: value.substring(0, CONCEPT_CREATOR_LIMITS.STRING_TRUNCATE)
-              })
+              message: interpolateHTML(
+                CONCEPT_CREATOR_TEXT.NO_CODE_SEARCH_MATCH,
+                {
+                  value: value.substring(0, CONCEPT_CREATOR_LIMITS.STRING_TRUNCATE)
+                }
+              )
             });
             
             return;
           }
 
-          // Disable future use now that the rule has been set
-          input.blur();
+          // If we reran search / changed search term, inform user of exchange count
+          if (prevCodeLength) {
+            this.#pushToast({
+              type: 'success',
+              message: interpolateHTML(
+                CONCEPT_CREATOR_TEXT.EXCHANGED_SEARCH_CODES,
+                {
+                  prev_code_len: prevCodeLength,
+                  new_code_len: codes.length.toLocaleString(),
+                  value: value.substring(0, CONCEPT_CREATOR_LIMITS.STRING_TRUNCATE),
+                }
+              )
+            });
+
+            return;
+          }
 
           // Inform user of result count
           this.#pushToast({
             type: 'success',
-            message: interpolateHTML(CONCEPT_CREATOR_TEXT.ADDED_SEARCH_CODES, {
-              code_len: codes.length.toLocaleString(),
-              value: value.substring(0, CONCEPT_CREATOR_LIMITS.STRING_TRUNCATE),
-            })
+            message: interpolateHTML(
+              CONCEPT_CREATOR_TEXT.ADDED_SEARCH_CODES,
+              {
+                code_len: codes.length.toLocaleString(),
+                value: value.substring(0, CONCEPT_CREATOR_LIMITS.STRING_TRUNCATE),
+              }
+            )
           });
         })
         .catch(() => { /* SINK */ });
@@ -1559,8 +1809,8 @@ export default class ConceptCreator {
   #handleRulesetAddition(e) {
     const target = e.target;
     const dropdown = target.parentNode.parentNode;
-
     const logicalType = dropdown.getAttribute('data-type');
+
     let sourceType = target.getAttribute('data-source');
     sourceType = CONCEPT_CREATOR_SOURCE_TYPES[sourceType];
     
@@ -1574,6 +1824,7 @@ export default class ConceptCreator {
                 code_len: content?.content?.data.length.toLocaleString(),
               })
             });
+
             this.#tryAddNewRule(logicalType, sourceType, content);
           })
           .catch(e => {
@@ -1583,6 +1834,32 @@ export default class ConceptCreator {
 
       case 'search-rule': {
         this.#tryAddNewRule(logicalType, sourceType);
+      } break;
+
+      case 'concept-rule': {
+        this.tryPromptConceptRuleImport()
+          .then(result => {
+
+            if (!this.#isConceptRuleImportDistinct(result, logicalType)) {
+              this.#pushToast({ type: 'danger', message: CONCEPT_CREATOR_TEXT.CONCEPT_RULE_IS_PRESENT});
+            } else {
+              this.#pushToast({
+                type: 'success',
+                message: interpolateHTML(CONCEPT_CREATOR_TEXT.ADDED_CONCEPT_CODES, {
+                  code_len: result?.codelist.length.toLocaleString(),
+                })
+              })
+  
+              this.#tryAddNewRule(logicalType, sourceType, result);
+            }
+          })
+          .catch(e => {
+            if (!isNullOrUndefined(e)) {
+              this.#pushToast({ type: 'danger', message: CONCEPT_CREATOR_TEXT.NO_CONCEPT_MATCH});
+              console.error(e);
+              return;
+            }
+          })
       } break;
 
       default: break;
@@ -1673,7 +1950,49 @@ export default class ConceptCreator {
     // Inform the parent form we're dirty
     this.makeDirty(data?.concept_id, data?.concept_version_id);
   }
-  
+
+  /**
+   * handleConceptImporting
+   * @desc handles the importing of a concept when a user interacts with the assoc. button
+   * @param {event} e the assoc. event
+   */
+  #handleConceptImporting(e) {
+    this.tryCloseEditor()
+      .then(() => {
+        return this.tryImportConcepts();
+      })
+      .then((concepts) => {
+        const failedImports = [];
+        for (let i = 0; i < concepts.length; ++i) {
+          const data = concepts[i];
+          if (!this.#isConceptImportDistinct(data)) {
+            failedImports.push(this.#generateConceptRuleSource(data));
+            continue;
+          }
+
+          data.imported = true;
+          this.data.push(data);
+
+          this.#tryRenderConceptComponent(data);
+        }
+        this.#toggleNoConceptBox(this.data.length > 0);
+
+        if (failedImports.length > 0) {
+          this.#pushToast({
+            type: 'danger',
+            message: interpolateHTML(CONCEPT_CREATOR_TEXT.CONCEPT_IMPORTS_ARE_PRESENT, {
+              failed: failedImports.join(', '),
+            }),
+          });
+        }
+      })
+      .catch((e) => {
+        if (!isNullOrUndefined(e)) {
+          console.error(e);
+        }
+      })
+  }
+
   /**
    * handleConceptCreation
    * @desc handles the creation of a concept when the user selects the 'Add Concept' button

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/entityCreator.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/forms/entityCreator.js
@@ -975,7 +975,7 @@ class EntityCreator {
    * @returns {boolean} whether the form has been modified and its data is now dirty
    */
   isDirty() {
-    return this.formChanged;
+    return this.data?.is_historical === 1 || this.formChanged;
   }
 
   /**

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
@@ -565,7 +565,7 @@ export class ConceptSelectionService {
    * @param {object|null} params query parameters to be provided to server to modify Concept results 
    * @returns {promise} a promise that resolves if the selection was confirmed, otherwise rejects
    */
-  show(view = CSEL_VIEWS.SEARCH, params = { }) {
+  show(view = CSEL_VIEWS.SEARCH, params) {
     params = params || { };
 
     // Reject immediately if we currently have a dialogue open

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
@@ -99,7 +99,11 @@ const CSEL_OPTIONS = {
   forceFilters: { },
 
   // Which filters, if any, to apply to children
-  childFilters: ['coding_system']
+  childFilters: ['coding_system'],
+
+  // Whether to cache the resulting queries for quicker,
+  // albeit possibly out of date, Phenotypes and their assoc. Concepts
+  useCachedResults: true,
 };
 
 /**
@@ -638,10 +642,13 @@ export class ConceptSelectionService {
    * @returns {array} the search results matching our current query 
    */
   async #tryGetSearchResults(cacheState = 'force-cache') {
+    if (!this.options?.useCachedResults) {
+      cacheState = 'reload';
+    }
+
     const query = this.#cleanQuery();
     const params = new URLSearchParams(query);
-
-    let request = {
+    const request = {
       method: 'GET',
       headers: {
         'X-Target': CSEL_BEHAVIOUR.ENDPOINTS.RESULTS,

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
@@ -1,0 +1,1571 @@
+/**
+ * CSEL_VIEWS
+ * @desc describes the view states of this component
+ */
+const CSEL_VIEWS = {
+  // The search view whereby users can select Concepts
+  SEARCH: 0,
+
+  // The current selection view, only accessible when allowMultiple flag is set to true
+  SELECTION: 1,
+};
+
+/**
+ * CSEL_EVENTS
+ * @desc used internally to track final state of dialogue
+ */
+const CSEL_EVENTS = {
+  // When a dialogue is cancelled without changes
+  CANCELLED: 0,
+
+  // When a dialogue is confirmed, with or without changes
+  CONFIRMED: 1,
+};
+
+/**
+ * CSEL_BEHAVIOUR
+ * @desc describes base behaviour of the service
+ */
+const CSEL_BEHAVIOUR = {
+  // Defines cache time for get requests (ms)
+  CACHE_TIME: 3_600_000, // i.e. 1hr
+
+  // Defines the output format behaviour of datetime objects
+  DATE_FORMAT: 'YYYY-MM-DD',
+
+  // Describes keycodes for filter-related events
+  KEY_CODES: {
+    ENTER: 13,
+  },
+
+  // Describes non-numerical data-value targets for pagination buttons
+  PAGINATION: {
+    NEXT: 'next',
+    PREVIOUS: 'previous',
+  },
+
+  // Describes the acceptable date formats when parsing
+  ACCEPTABLE_DATE_FORMAT: ['DD-MM-YYYY', 'MM-DD-YYYY', 'YYYY-MM-DD'],
+
+  // Describes the query URL
+  QUERY_URL: '/query',
+
+  // Describes endpoints used to ret. data
+  ENDPOINTS: {
+    SPECIFICATION: 'get_filters',
+    RESULTS: 'get_results',
+  }
+}
+
+/**
+ * CSEL_OPTIONS
+ * @desc Available options for this component,
+ *       where each of the following options are used as default values
+ *       and are appended automatically if not overriden.
+ */
+const CSEL_OPTIONS = {
+  // Template
+  template: 1,
+
+  // Allow more than a single Concept to be selected
+  allowMultiple: true,
+
+  // Whether to remember the selection when previously opened
+  //  [!] Note: Only works when allowMultiple flag is set to true
+  maintainSelection: true,
+
+  // Flag to determine whether we scroll to the top of the result page when pagination occurs
+  scrollOnResultChange: true,
+
+  // The title of the prompt
+  promptTitle: 'Import Concepts',
+
+  // The confirm button text
+  promptConfirm: 'Confirm',
+
+  // The cancel button text
+  promptCancel: 'Cancel',
+
+  // The size of the prompt (ModalFactory.ModalSizes.%s, i.e., {sm, md, lg})
+  promptSize: 'lg',
+
+  // Whether to maintain applied filters when user enters/exits the search dialogue
+  maintainFilters: true,
+
+  // Filters to ignore (by field name)
+  ignoreFilters: [ ],
+
+  // Force context of filters
+  forceFilters: { },
+
+  // Which filters, if any, to apply to children
+  childFilters: ['coding_system']
+};
+
+/**
+ * CSEL_BUTTONS
+ * @desc The styleguide for the prompt's buttons
+ */
+const CSEL_BUTTONS = {
+  CONFIRM: '<button class="primary-btn text-accent-darkest bold secondary-accent" aria-label="Confirm" id="confirm-button"></button>',
+  CANCEL: '<button class="secondary-btn text-accent-darkest bold washed-accent" aria-label="Cancel" id="reject-button"></button>',
+};
+
+/**
+ * CSEL_INTERFACE
+ * @desc defines the HTML used to render the selection interface
+ */
+const CSEL_INTERFACE = {
+  // Main dialogue modal
+  DIALOGUE: ' \
+  <div class="target-modal target-modal-${promptSize}" id="${id}" aria-hidden="true"> \
+    <div class="target-modal__container"> \
+      <div class="target-modal__header"> \
+        <h2 id="target-modal-title">${promptTitle}</h2> \
+      </div> \
+      <div class="target-modal__body" id="target-modal-content"> \
+      </div> \
+    </div> \
+  </div>',
+
+  // Tabbed views when allowMultiple flag is active
+  TAB_VIEW: ' \
+  <div class="tab-view" id="tab-view"> \
+    <div class="tab-view__tabs tab-view__tabs-z-buffer"> \
+      <button aria-label="tab" id="SEARCH" class="tab-view__tab active">Search Concepts</button> \
+      <button aria-label="tab" id="SELECTION" class="tab-view__tab">Selected Concepts</button> \
+    </div> \
+    <div class="tab-view__content" id="tab-content"> \
+    </div> \
+  </div>',
+
+  SELECTION_VIEW: ' \
+  <div class="detailed-input-group fill no-margin"> \
+    <div class="detailed-input-group__header"> \
+      <div class="detailed-input-group__header-item"> \
+        <p class="detailed-input-group__description">Your currently selected items:</p> \
+      </div> \
+    </div> \
+    <fieldset class="code-search-group indented scrollable slim-scrollbar" id="item-list"> \
+    </fieldset> \
+  </div>',
+
+  // Base search view
+  SEARCH_VIEW: ' \
+  <div class="search-page as-selection" id="selection-search"> \
+    <aside class="selection-filters"> \
+      <div class="selection-filters__header"> \
+        <h3>Filter By</h3> \
+      </div> \
+      <div class="selection-filters__container slim-scrollbar" id="search-filters"> \
+      </div> \
+    </aside> \
+    <section class="entity-search-results"> \
+      <div class="entity-search-results__header"> \
+        <div class="entity-search-results__header-results" id="search-response-header"> \
+          <h4>Results</h4> \
+          <p></p> \
+        </div> \
+        <div class="entity-search-results__header-modifiers"> \
+          <div class="selection-group"> \
+            <p class="selection-group__title">Order By:</p> \
+            <select id="order-by-filter" placeholder-text="By Relevance" data-element="dropdown" data-field="order_by" data-class="option"> \
+              <option value="1" class="dropdown-selection__list-item" selected>By Relevance</option> \
+              <option value="2" class="dropdown-selection__list-item">Created (Asc)</option> \
+              <option value="3" class="dropdown-selection__list-item">Created (Desc)</option> \
+              <option value="4" class="dropdown-selection__list-item">Updated (Asc)</option> \
+              <option value="5" class="dropdown-selection__list-item">Updated (Desc)</option> \
+            </select> \
+          </div> \
+        </div> \
+      </div> \
+      <div class="entity-search-results__container scrollable slim-scrollbar" id="search-response-content"> \
+      </div> \
+      <div class="pagination-box push-bottom" id="search-pagination-area"> \
+      </div> \
+    </section> \
+  </div>',
+
+  // Search view pagination controls
+  SEARCH_PAGINATION: ' \
+  <section class="pagination-container" data-field="page" data-class="pagination" data-value="${page}"> \
+    <div class="pagination-container__details"> \
+      <p class="pagination-container__details-number"><span id="page-number">${page}</span> / <span id="page-total">${page_total}</span></p> \
+    </div> \
+    <ul class="pagination-container__previous"> \
+      <li class="${prev_disabled ? "disabled" : ""}"> \
+        <a data-value="previous" data-field="page" aria-label="Go Previous Page" tabindex="0" role="button">Previous</a> \
+      </li> \
+    </ul> \
+    <ul class="pagination-container__next"> \
+      <li class="${next_disabled ? "disabled" : ""}"> \
+        <a data-value="next" data-field="page" aria-label="Go Next Page" tabindex="0" role="button">Next</a> \
+      </li> \
+    </ul> \
+  </section>',
+
+  // Search result card
+  RESULT_CARD: ' \
+  <article class="entity-card inactive" data-entity-id="${id}" data-entity-version-id="${history_id}" style="padding: 0;"> \
+    <div class="entity-card__header"> \
+      <div class="entity-card__header-item"> \
+        <h3 class="entity-card__title">${id}/${history_id} - ${name}</h3> \
+        <p class="entity-card__author">${author}</p> \
+      </div> \
+    </div> \
+    <div class="entity-card__snippet"> \
+      ${tags} \
+      <div class="entity-card__snippet-datagroup" id="datagroup"> \
+      </div> \
+    </div> \
+  </article>',
+
+  // Card chip tags group
+  CHIP_GROUP: ' \
+  <div class="entity-card__snippet-tags"> \
+    <div class="entity-card__snippet-tags-group" id="chip-tags"> \
+      ${tags} \
+    </div> \
+  </div>',
+
+  // Card chip for result card
+  CHIP_TAGS: ' \
+  <div class="meta-chip meta-chip-washed-accent"> \
+    <span class="meta-chip__name meta-chip__name-text-accent-dark meta-chip__name-bold">${name}</span> \
+  </div>',
+
+  // Card accordian for children data
+  CARD_ACCORDIAN: ' \
+  <div class="fill-accordian" id="children-accordian-${id}" style="margin-top: 0.5rem"> \
+    <input class="fill-accordian__input" id="children-${id}" name="children-${id}" type="checkbox" /> \
+    <label class="fill-accordian__label" id="children-${id}" for="children-${id}" role="button" tabindex="0"> \
+      <span>${title}</span> \
+    </label> \
+    <article class="fill-accordian__container" id="data" style="padding: 0.5rem;"> \
+      ${content} \
+    </article> \
+  </div>',
+
+  // Child selector for cards
+  CHILD_SELECTOR: ' \
+  <div class="checkbox-item-container ${!isSelector? "ignore-overflow" : ""}" id="${isSelector ? "child-selector" : "selected-item" }"> \
+    <input id="${field}-${id}" aria-label="${title}" type="checkbox" ${checked ? "checked" : ""} data-index="${index}" \
+      class="checkbox-item" data-id="${id}" data-history="${history_id}" data-name="${title}" data-field="${field}" data-prefix="${prefix}"/> \
+    <label for="${field}-${id}" class="constrained-filter-item">${title}</label> \
+  </div>',
+};
+
+const CSEL_FILTER_COMPONENTS = {
+  CHECKBOX: ' \
+  <div class="checkbox-item-container"> \
+    <input id="${field}-${pk}" aria-label="${value}" type="checkbox" class="checkbox-item" data-value="${pk}" data-name="${value}" data-class="checkbox" data-field="${field}" /> \
+    <label for="${field}-${pk}" class="constrained-filter-item">${value}</label> \
+  </div>',
+
+  CHECKBOX_GROUP: ' \
+  <div class="accordian" data-class="checkbox" data-field="${field}" data-type="${datatype}" \
+    role="collapsible" tabindex="0" aria-labelledby="${title} Filters" aria-controls="filter-${field}"> \
+    <input class="accordian__input" id="filter-${field}" name="filter-${field}" type="checkbox" /> \
+    <label class="accordian__label" for="filter-${field}"> \
+      <h4>${title}</h4> \
+    </label> \
+    <article class="accordian__container"> \
+      <div class="filter-group filter-scrollbar"> \
+      </div> \
+    </article> \
+  </div>',
+
+  DATEPICKER_GROUP: ' \
+  <div class="accordian" data-class="datepicker" data-field="${field}" data-type="${datatype}" \
+    role="collapsible" tabindex="0" aria-labelledby="${title} Filters" aria-controls="filter-${field}"> \
+    <input class="accordian__input" id="filter-${field}" name="filter-${field}" type="checkbox" /> \
+    <label class="accordian__label" for="filter-${field}"> \
+      <h4>${title}</h4> \
+    </label> \
+    <article class="accordian__container"> \
+      <fieldset class="date-range-field wrapped" id="filter-${field}-fields" data-class="daterange" data-field="${field}"> \
+        <div> \
+          <span class="date-range-field__label">Start:</span> \
+          <input type="date" value="" data-field="${field}" \
+            aria-label="${title} - Select start date" data-type="start" id="${field}-startdate"> \
+        </div> \
+        <div> \
+          <span class="date-range-field__label">End:</span> \
+          <input type="date" value="" data-field="${field}" \
+            aria-label="${title} - Select end date" data-type="end" id="${field}-enddate"> \
+        </div> \
+      </fieldset> \
+    </article> \
+  </div>',
+
+  SEARCHBAR_GROUP: ' \
+  <div class="accordian" data-class="searchbar" data-field="search" data-type="string" \
+    role="collapsible" tabindex="0" aria-labelledby="Searchterm Filter" aria-controls="filter-search"> \
+    <input class="accordian__input" id="filter-search" name="filter-search" type="checkbox" /> \
+    <label class="accordian__label" for="filter-search"> \
+      <h4>Search</h4> \
+    </label> \
+    <article class="accordian__container"> \
+      <div class="filter-group filter-scrollbar"> \
+        <input class="code-text-input" aria-label="Search by term..." type="text" id="searchterm" \
+          placeholder="Search..." minlength="3" value="" data-class="searchbar" data-field="search" \
+          style="width: calc(100% - 3rem);"> \
+      </div> \
+    </article> \
+  </div>'
+};
+
+/**
+ * CSEL_FILTER_CLEANSERS
+ * @desc Cleans the value of a query by its class
+ */
+const CSEL_FILTER_CLEANSERS = {
+  CHECKBOX: (value) => value.length > 0 ? value.join(',') : null,
+  DATEPICKER: (value) => (!isNullOrUndefined(value.start) && !isNullOrUndefined(value.end)) ? `${value.start},${value.end}` : null,
+  SEARCHBAR: (value) => !isStringEmpty(value) ? value : null,
+  PAGINATION: (value) => value != 1 ? value : null,
+  OPTION: (value) => value != 1 ? value : null,
+};
+
+/**
+ * CSEL_FILTER_GENERATORS
+ * @desc Describes how to generate filter groups by their class
+ */
+const CSEL_FILTER_GENERATORS = {
+  // creates a checkbox filter group
+  CHECKBOX: (container, data) => {
+    if (!data?.options || data.options.length < 1) {
+      return;
+    }
+
+    let html = interpolateHTML(CSEL_FILTER_COMPONENTS.CHECKBOX_GROUP, {
+      field: data.details.field,
+      title: data.details.title,
+      datatype: data.details.type,
+    });
+
+    let doc = parseHTMLFromString(html);
+    let group = container.appendChild(doc.body.children[0]);
+    let descendants = group.querySelector('.filter-group');
+    for (let i = 0; i < data.options.length; ++i) {
+      let option = data.options[i];
+
+      html = interpolateHTML(CSEL_FILTER_COMPONENTS.CHECKBOX, {
+        pk: option.pk,
+        field: data.details.field,
+        value: option.value,
+      });
+      doc = parseHTMLFromString(html);
+      descendants.appendChild(doc.body.children[0]);
+    }
+
+    return group;
+  },
+
+  // creates a datepicker filter group
+  DATEPICKER: (container, data) => {
+    let html = interpolateHTML(CSEL_FILTER_COMPONENTS.DATEPICKER_GROUP, {
+      field: data.details.field,
+      title: data.details.title,
+      datatype: data.details.type,
+    });
+
+    let doc = parseHTMLFromString(html);
+    return container.appendChild(doc.body.children[0]);
+  },
+
+  // creates a searchbar filter group
+  SEARCHBAR: (container, data) => {
+    let html = CSEL_FILTER_COMPONENTS.SEARCHBAR_GROUP;
+    let doc = parseHTMLFromString(html)
+    return container.appendChild(doc.body.children[0]);
+  },
+}
+
+/**
+ * ConceptSelectionService
+ * @desc Class that can be used to prompt users to select 1 or more concepts
+ *       from a list given by the server, where:
+ *          
+ *          1. The owner phenotype is published
+ *            OR
+ *          2. The requesting user has access to the child concepts via permissions
+ * 
+ */
+export class ConceptSelectionService {
+  static Views = CSEL_VIEWS;
+
+  constructor(options, data) {
+    this.id = generateUUID();
+    this.options = mergeObjects(options || { }, CSEL_OPTIONS);
+    this.query = { }
+
+    if (this.options.allowMultiple) {
+      this.data = data || [ ];
+    } else {
+      this.data = [ ];
+    }
+  }
+
+
+  /*************************************
+   *                                   *
+   *               Getter              *
+   *                                   *
+   *************************************/
+  /**
+   * getID
+   * @desc gets the ID associated with this instance
+   * @returns {string} the assoc. UUID
+   */
+  getID() {
+    return this.id;
+  }
+
+  /**
+   * getQuery
+   * @desc gets the current search query params
+   * @returns {object} the current query
+   */
+  getQuery() {
+    return this.query;
+  }
+
+  /**
+   * getSelection
+   * @desc gets the currently selected concepts
+   * @returns {array} the assoc. data
+   */
+  getSelection() {
+    return this.data;
+  }
+
+  /**
+   * isOpen
+   * @desc reflects whether the dialogue is currently open
+   * @returns {boolean} whether the dialogue is open
+   */
+  isOpen() {
+    return !!this.dialogue;
+  }
+
+  /**
+   * getDialogue
+   * @desc get currently active dialogue, if any
+   * @returns {object} the dialogue and assoc. elems/methods
+   */
+  getDialogue() {
+    return this.dialogue;
+  }
+
+  isSelected(childId, childVersion) {
+    if (isNullOrUndefined(this.dialogue?.data)) {
+      return false;
+    }
+
+    return !!this.dialogue.data.find(item => {
+      return item.id == childId && item.history_id == childVersion;
+    });
+  }
+  
+  /*************************************
+   *                                   *
+   *               Setter              *
+   *                                   *
+   *************************************/  
+  /**
+   * setSelection
+   * @desc sets the currently selected concepts
+   * @param {array} data the desired selected objects
+   */
+  setSelection(data) {
+    data = data || [ ];
+
+    if (this.options.allowMultiple) {
+      this.data = data;
+    }
+    return this;
+  }
+
+
+  /*************************************
+   *                                   *
+   *               Public              *
+   *                                   *
+   *************************************/
+  /**
+   * show
+   * @desc shows the dialogue
+   * @param {enum|int} view the view to open the modal with 
+   * @param {object|null} params query parameters to be provided to server to modify Concept results 
+   * @returns {promise} a promise that resolves if the selection was confirmed, otherwise rejects
+   */
+  show(view = CSEL_VIEWS.SEARCH, params = { }) {
+    params = params || { };
+
+    // Reject immediately if we currently have a dialogue open
+    if (this.dialogue) {
+      return Promise.reject();
+    }
+
+    return this.#fetchFilterGroups()
+      .then(() => new Promise((resolve, reject) => {
+        this.#buildDialogue(params);
+        this.#renderView(view);
+
+        this.dialogue.element.addEventListener('selectionUpdate', (e) => {
+          this.close();
+  
+          const detail = e.detail;
+          const eventType = detail.type;
+          const data = detail.data;
+          switch (eventType) {
+            case CSEL_EVENTS.CONFIRMED: {
+              if (this.options.allowMultiple && this.options.maintainSelection) {
+                this.data = data;
+              }
+  
+              if (this.options.allowMultiple) {
+                resolve(data);
+                return;
+              }
+              resolve(data?.[0]);
+            } break;
+  
+            case CSEL_EVENTS.CANCELLED: {
+              reject();
+            } break;
+  
+            default: break;
+          }
+        });
+        
+        this.dialogue.show();
+      }));
+  }
+  
+  /**
+   * close
+   * @desc closes the dialogue if active
+   */
+  close() {
+    if (this.dialogue) {
+      this.dialogue.close();
+    }
+
+    return this;
+  }
+
+
+  /*************************************
+   *                                   *
+   *              Private              *
+   *                                   *
+   *************************************/
+  /**
+   * cleanQuery
+   * @desc collects the data assoc. with each filter after cleaning & applies any forced filters
+   * @returns {object} the cleaned query
+   */
+  #cleanQuery() {
+    // clean the query object
+    let cleaned = { };
+    for (let key in this.query) {
+      let value = this.query[key];
+      if (this.filters.hasOwnProperty(key)) {
+        let filterItem = this.filters[key];
+        let uppercase = filterItem.component.toLocaleUpperCase();
+        if (CSEL_FILTER_CLEANSERS.hasOwnProperty(uppercase)) {
+          value = CSEL_FILTER_CLEANSERS[uppercase](value);
+        }
+      }
+
+      if (isNullOrUndefined(value)) {
+        continue;
+      }
+      cleaned[key] = value;
+    }
+
+    return cleaned;
+  }
+
+  /**
+   * fetchFilterGroups
+   * @returns {object} the spec. for template & metadata filter groups if awaited, otherwise res. a promise
+   */
+  async #fetchFilterGroups() {
+    if (this.filterGroups) {
+      return this.filterGroups;
+    }
+
+    const response = await fetch(
+      `${CSEL_BEHAVIOUR.QUERY_URL}/${this.options?.template}`,
+      {
+        method: 'GET',
+        headers: {
+          'X-Target': CSEL_BEHAVIOUR.ENDPOINTS.SPECIFICATION,
+          'X-Requested-With': 'XMLHttpRequest',
+        }
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`An error has occurred: ${response.status}`);
+    }
+
+    let res;
+    try {
+      res = await response.json();
+    }
+    catch (e) {
+      throw new Error(`An error has occurred: ${e}`); 
+    }
+
+    if (this.options?.ignoreFilters) {
+      Object.keys(res).forEach((key, index) => {
+        res[key] = res[key].filter(item => !this.options.ignoreFilters.includes(item?.details?.field));
+      });
+    }
+
+    this.filterGroups = res;
+    return this.filterGroups;
+  }
+
+  /**
+   * tryGetSearchResults
+   * @desc GET request to search endpoint for results that relate to options & filter params
+   * @param {string} cacheState which cache state to use
+   * @returns {array} the search results matching our current query 
+   */
+  async #tryGetSearchResults(cacheState = 'force-cache') {
+    const query = this.#cleanQuery();
+    const params = new URLSearchParams(query);
+
+    let request = {
+      method: 'GET',
+      headers: {
+        'X-Target': CSEL_BEHAVIOUR.ENDPOINTS.RESULTS,
+        'X-Requested-With': 'XMLHttpRequest',
+      }
+    };
+
+    if (cacheState) {
+      request.cache = cacheState;
+    }
+
+    const response = await fetch(
+      `${CSEL_BEHAVIOUR.QUERY_URL}/${this.options?.template}/?` + params,
+      request
+    );
+
+    if (!response.ok) {
+      throw new Error(`An error has occurred: ${response.status}`);
+    }
+
+    if (cacheState !== 'reload') {
+      const date = response.headers.get('date');
+      const delta = date ? new Date(date).getTime() : 0;
+      if (delta < Date.now() - CSEL_BEHAVIOUR.CACHE_TIME) {
+        return this.#tryGetSearchResults('reload');
+      }
+    }
+
+    let res;
+    try {
+      res = await response.json();
+    }
+    catch (e) {
+      throw new Error(`An error has occurred: ${e}`); 
+    }
+
+    return res;
+  }
+
+  /**
+   * getFilterSafeChildren
+   * @desc applies filters to a child object if present within the query, e.g. coding system(s)
+   * @param {list|null} children the list of children associated with a child object
+   * @returns {list|null} the list of filtered children (or null if no children present)
+   */
+  #getFilterSafeChildren(children) {
+    if (isNullOrUndefined(children) || children.length < 1) {
+      return;
+    }
+
+    const childFilters = this.options?.childFilters;
+    if (isNullOrUndefined(childFilters)) {
+      return children;
+    }
+
+    let output = [ ];
+    for (let i = 0; i < children.length; ++i) {
+      let child = children[i];
+      let passed = true;
+      for (let j = 0; j < childFilters.length; ++j) {
+        let filter = childFilters[j];
+        let query = this.query?.[filter];
+        if (isNullOrUndefined(child?.[filter]) || (!isNullOrUndefined(query) && child[filter] != query)) {
+          passed = false;
+        }
+      }
+
+      if (passed) {
+        output.push(child);
+      }
+    }
+
+    return output;
+  }
+
+  /**
+   * resetPage
+   * @desc Force reset page on filter mutation
+   */
+  #resetPage() {
+    if (isNullOrUndefined(this.query.page)) {
+      return;
+    }
+    this.query.page = 1;
+  }
+
+  /*************************************
+   *                                   *
+   *               Render              *
+   *                                   *
+   *************************************/
+  /**
+   * buildDialogue
+   * @desc renders the top-level modal according to the options given
+   * @param {object} params the given query params
+   * @returns {object} the dialogue object as assigned to this.dialogue
+   */
+  #buildDialogue(params) {
+    // create dialogue
+    const currentHeight = window.scrollY;
+    let html = interpolateHTML(CSEL_INTERFACE.DIALOGUE, {
+      id: this.id,
+      promptTitle: this.options?.promptTitle,
+      promptSize: this.options?.promptSize,      
+    });
+  
+    let doc = parseHTMLFromString(html);
+    let modal = document.body.appendChild(doc.body.children[0]);
+    
+    // create footer
+    let footer = createElement('div', {
+      id: 'target-modal-footer',
+      class: 'target-modal__footer',
+    });
+  
+    const container = modal.querySelector('.target-modal__container');
+    footer = container.appendChild(footer);
+    
+    // create buttons
+    const buttons = { };
+    let confirmBtn = parseHTMLFromString(CSEL_BUTTONS.CONFIRM);
+    confirmBtn = footer.appendChild(confirmBtn.body.children[0]);
+    confirmBtn.innerText = this.options.promptConfirm;
+
+    let cancelBtn = parseHTMLFromString(CSEL_BUTTONS.CANCEL);
+    cancelBtn = footer.appendChild(cancelBtn.body.children[0]);
+    cancelBtn.innerText = this.options.promptCancel;
+
+    buttons['confirm'] = confirmBtn;
+    buttons['cancel'] = cancelBtn;
+
+    // initiate main event handling
+    buttons?.confirm.addEventListener('click', this.#handleConfirm.bind(this));
+    buttons?.cancel.addEventListener('click', this.#handleCancel.bind(this));
+
+    // create content handler
+    const body = container.querySelector('#target-modal-content');
+    if (this.options?.allowMultiple) {
+      body.classList.add('no-pad');
+    }
+
+    let contentContainer = body;
+    if (this.options.allowMultiple) {
+      html = CSEL_INTERFACE.TAB_VIEW;
+      doc = parseHTMLFromString(html);
+      contentContainer = body.appendChild(doc.body.children[0]);
+      
+      const tabs = contentContainer.querySelectorAll('button.tab-view__tab');
+      for (let i = 0; i < tabs.length; ++i) {
+        tabs[i].addEventListener('click', this.#changeTabView.bind(this));
+      }
+
+      contentContainer = contentContainer.querySelector('#tab-content');
+    }
+
+    // build dialogue
+    this.dialogue = {
+      // data
+      data: this.options?.maintainSelection ? this.data : [],
+      params: params,
+      view: CSEL_VIEWS.SEARCH,
+
+      // dialogue elements
+      element: modal,
+      buttons: buttons,
+      content: contentContainer,
+
+      // dialogue methods
+      show: () => {
+        createElement('a', { href: `#${this.id}` }).click();
+        window.scrollTo({ top: currentHeight, left: window.scrollX, behaviour: 'instant'});
+    
+        // inform screen readers of alert
+        modal.setAttribute('aria-hidden', false);
+        modal.setAttribute('role', 'alert');
+        modal.setAttribute('aria-live', true);
+        
+        // stop body scroll
+        document.body.classList.add('modal-open');
+      },
+      close: () => {
+        this.dialogue = null;
+
+        document.body.classList.remove('modal-open');
+        modal.remove();
+        history.replaceState({ }, document.title, '#');
+        window.scrollTo({ top: currentHeight, left: window.scrollX, behaviour: 'instant'});
+      },
+    };
+
+    return this.dialogue;
+  }
+
+  /**
+   * renderView
+   * @desc renders the given view
+   * @param {enum|int} view the view to render within the active dialogue
+   */
+  #renderView(view) {
+    if (!this.isOpen()) {
+      return;
+    }
+    
+    if (!this.options.allowMultiple && view == CSEL_VIEWS.SELECTION) {
+      view = CSEL_VIEWS.SEARCH;
+    }
+    this.dialogue.view = view;
+
+    const content = this.dialogue?.content;
+    if (!isNullOrUndefined(content)) {
+      content.innerHTML = '';
+    }
+
+    if (this.options.allowMultiple) {
+      this.#pushActiveTab(view);
+    }
+
+    switch (view) {
+      case CSEL_VIEWS.SEARCH: {
+        this.#renderSearchView();
+      } break;
+
+      case CSEL_VIEWS.SELECTION: {
+        this.#renderSelectionView();
+      } break;
+
+      default: break;
+    }
+  }
+
+  /**
+   * renderSearchView
+   * @desc renders the search view where users can select concepts to import
+   */
+  #renderSearchView() {
+    // Draw page
+    let html = CSEL_INTERFACE.SEARCH_VIEW;
+    let doc = parseHTMLFromString(html);
+    let page = this.dialogue.content.appendChild(doc.body.children[0]);
+    this.dialogue.page = page;
+    
+    // Draw content
+    this.filters = { };
+    if (!this.options?.maintainFilters) {
+      this.query = { };
+    }
+
+    if (this.options?.forceFilters) {
+      this.query = mergeObjects(this.query, this.options.forceFilters);
+    }
+    
+    this.#paintSearchFilters();
+    this.#tryGetSearchResults()
+      .then((results) => this.#paintSearchResults(results))
+      .catch(console.warn);
+  }
+
+  /**
+   * renderSelectionView
+   * @desc renders the selection view where users can manage their currently selected concepts
+   */
+  #renderSelectionView() {
+    // Draw page
+    let html = CSEL_INTERFACE.SELECTION_VIEW;
+    let doc = parseHTMLFromString(html);
+    let page = this.dialogue.content.appendChild(doc.body.children[0]);
+    this.dialogue.page = page;
+
+    // Draw content
+    this.#paintSelectionList();
+  }
+
+  /**
+   * pushActiveTab
+   * @desc updates the tab view objects when allowMultiple flag is true
+   * @param {int|enum} view an enum of CSEL_VIEWS
+   */
+  #pushActiveTab(view) {
+    let tabs = this.dialogue.element.querySelectorAll('button.tab-view__tab');
+    for (let i = 0; i < tabs.length; ++i) {
+      let tab = tabs[i];
+      let relative = tab.getAttribute('id');
+      if (!CSEL_VIEWS.hasOwnProperty(relative)) {
+        continue;
+      }
+
+      relative = CSEL_VIEWS[relative];
+      if (relative == view) {
+        tab.classList.add('active');
+      } else {
+        tab.classList.remove('active');
+      }
+    }
+  }
+
+  /**
+   * paintSelectionList
+   * @desc renders the selected items
+   */
+  #paintSelectionList() {
+    const page = this.dialogue.page;
+    if (!this.dialogue?.view == CSEL_VIEWS.SELECTION || isNullOrUndefined(page)) {
+      return;
+    }
+
+    const content = page.querySelector('#item-list');
+    if (isNullOrUndefined(content)) {
+      return;
+    }
+
+    for (let i = 0; i < this.dialogue?.data.length; ++i) {
+      let selected = this.dialogue?.data?.[i];
+      let html = interpolateHTML(CSEL_INTERFACE.CHILD_SELECTOR, {
+        'id': selected.id,
+        'history_id': selected.history_id,
+        'field': selected.type,
+        'title': `${selected.prefix}${selected.id}/${selected.history_id} - ${selected.name}`,
+        'prefix': selected.prefix,
+        'checked': true,
+        'isSelector': false,
+        'index': i,
+      });
+
+      let doc = parseHTMLFromString(html);
+      let checkbox = content.appendChild(doc.body.children[0]);
+      checkbox.addEventListener('change', this.#handleSelectedItem.bind(this));
+    }
+  }
+
+  /**
+   * paintSearchFilters
+   * @desc renders the filters per the spec
+   */
+  #paintSearchFilters() {
+    const filterContainer = this.dialogue.page.querySelector('#search-filters');
+    if (isNullOrUndefined(filterContainer)) {
+      return;
+    }
+
+    // Paint searchbar
+    const searchbar = CSEL_FILTER_GENERATORS.SEARCHBAR(filterContainer);
+    this.filters['search'] = {
+      name: 'search',
+      filter: searchbar,
+      component: 'searchbar',
+      datatype: 'string',
+    };
+    this.#handleClientInteraction(this.filters['search']);
+
+    // Paint order by filter
+    const orderFilter = this.dialogue.page.querySelector('#order-by-filter');
+    createDropdownSelectionElement(orderFilter);
+    this.filters['order_by'] = {
+      name: 'order_by',
+      filter: orderFilter,
+      component: 'option',
+      datatype: 'int',
+    };
+    this.#handleClientInteraction(this.filters['order_by']);
+
+    // Paint metadata -> template filterable fields
+    const { metadata, template } = this.filterGroups;
+    for (let i = 0; i < metadata.length; ++i) {
+      const group = metadata[i];
+      const handler = CSEL_FILTER_GENERATORS[group?.details?.component.toLocaleUpperCase()];
+      if (isNullOrUndefined(handler)) {
+        continue;
+      }
+
+      const filterComponent = handler(filterContainer, group);
+      if (isNullOrUndefined(filterComponent)) {
+        continue;
+      }
+
+      this.filters[group?.details?.field] = {
+        name: group?.details?.field,
+        fieldtype: 'metadata',
+        filter: filterComponent,
+        component: group?.details?.component,
+        datatype: group?.details?.type,
+      };
+      this.#handleClientInteraction(this.filters[group?.details?.field]);
+    }
+
+    for (let i = 0; i < template.length; ++i) {
+      const group = template[i];
+      const handler = CSEL_FILTER_GENERATORS[group?.details?.component.toLocaleUpperCase()];
+      if (isNullOrUndefined(handler)) {
+        continue;
+      }
+
+      const filterComponent = handler(filterContainer, group);
+      if (isNullOrUndefined(filterComponent)) {
+        continue;
+      }
+
+      this.filters[group?.details?.field] = {
+        name: group?.details?.field,
+        fieldtype: 'template',
+        filter: filterComponent,
+        component: group?.details?.component,
+        datatype: group?.details?.type,
+      };
+      this.#handleClientInteraction(this.filters[group?.details?.field]);
+    }
+  }
+
+  /**
+   * paintSearchPagination
+   * @desc paints the pagination controller
+   * @param {array} results the results as returned from the search api
+   */
+  #paintSearchPagination(response) {
+    const page = this.dialogue.page;
+    if (!this.dialogue?.view == CSEL_VIEWS.SEARCH || isNullOrUndefined(page)) {
+      return;
+    }
+
+    const pageContainer = page.querySelector('#search-pagination-area');
+    if (isNullOrUndefined(pageContainer)) {
+      return;
+    }
+    pageContainer.innerHTML = '';
+
+    // paint new pagination
+    let html = interpolateHTML(CSEL_INTERFACE.SEARCH_PAGINATION, {
+      'page': response?.details?.page,
+      'page_total': response?.details?.total,
+      'prev_disabled': !response?.details?.has_previous,
+      'next_disabled': !response?.details?.has_next,
+    });
+
+    let doc = parseHTMLFromString(html);
+    let pagination = pageContainer.appendChild(doc.body.children[0]);
+
+    this.filters['page'] = {
+      name: 'page',
+      filter: pagination,
+      component: 'pagination',
+      datatype: 'int',
+    };
+    this.#handleClientInteraction(this.filters['page']);
+
+    // update page result count
+    const textCounter = page.querySelector('#search-response-header > p');
+    if (textCounter) {
+      textCounter.innerText = `${response?.details?.start_index}-${response?.details?.end_index} of over ${response?.details?.max_results.toLocaleString()}`;
+    }    
+  }
+
+  /**
+   * paintSearchResults
+   * @desc makes a request to the endpoint to get search results and paints them to the screen
+   * @param {array} results the results as returned from the search api
+   */
+  #paintSearchResults(response) {
+    const page = this.dialogue.page;
+    if (!this.dialogue?.view == CSEL_VIEWS.SEARCH || isNullOrUndefined(page)) {
+      return;
+    }
+
+    const resultContainer = page.querySelector('#search-response-content');
+    if (isNullOrUndefined(resultContainer)) {
+      return;
+    }
+
+    // first clear prev. results
+    resultContainer.innerHTML = '';
+
+    // then render cards, apply selection to concepts if found
+    const results = response?.results || [ ];
+    for (let i = 0; i < results.length; ++i) {
+      let result = results[i];
+      let children = this.#getFilterSafeChildren(result?.children);
+      if (isNullOrUndefined(children) || children.length < 1) {
+        continue;
+      }
+
+      let html = interpolateHTML(CSEL_INTERFACE.RESULT_CARD, {
+        'id': result?.id,
+        'name': result?.name,
+        'history_id': result?.history_id,
+        'author': result?.author || '',
+        'tags': '',
+      });
+      
+      let doc = parseHTMLFromString(html);
+      let card = resultContainer.appendChild(doc.body.children[0]);
+      let datagroup = card.querySelector('#datagroup');
+
+      let childContents = '';
+      for (let j = 0; j < children.length; ++j) {
+        let child = children[j];
+        childContents += interpolateHTML(CSEL_INTERFACE.CHILD_SELECTOR, {
+          'id': child.id,
+          'history_id': child.history_id,
+          'field': child.type,
+          'title': `${child.prefix}${child.id}/${child.history_id} - ${child.name}`,
+          'checked': this.isSelected(child.id, child.history_id),
+          'prefix': child.prefix,
+          'isSelector': true,
+          'index': -1,
+        });
+      }
+
+      html = interpolateHTML(CSEL_INTERFACE.CARD_ACCORDIAN, {
+        id: result?.id,
+        title: `Available Concepts (${children.length})`,
+        content: childContents,
+      });
+      doc = parseHTMLFromString(html);
+
+      let accordian = datagroup.appendChild(doc.body.children[0]);
+      let checkboxes = accordian.querySelectorAll('#child-selector > input[type="checkbox"]');
+      for (let j = 0; j < checkboxes.length; j++) {
+        let checkbox = checkboxes[j];
+        checkbox.addEventListener('change', this.#handleChildSelection.bind(this));
+      }
+    }
+
+    this.#paintSearchPagination(response);
+  }
+
+  /*************************************
+   *                                   *
+   *               Events              *
+   *                                   *
+   *************************************/
+  /**
+   * handleClientInteraction
+   * @desc initiates event handling for filters
+   * @param {object} filterGroup the filter group as described by the spec 
+   */
+  #handleClientInteraction(filterGroup) {
+    switch (filterGroup.component) {
+      case 'checkbox': {
+        const checkboxes = filterGroup.filter.querySelectorAll('.checkbox-item');
+        let query = this.query?.[filterGroup.name];
+        for (let i = 0; i < checkboxes.length; ++i) {
+          let checkbox = checkboxes[i];
+          let value = checkbox.getAttribute('data-value');
+          if (!isNullOrUndefined(value) && !isNullOrUndefined(query)) {
+            let index = query.indexOf(value);
+            if (index >= 0) {
+              checkbox.checked = true;
+            }
+          }
+          
+          checkbox.addEventListener('change', this.#handleCheckboxUpdate.bind(this));
+        }
+      } break;
+
+      case 'datepicker': {
+        const dateinputs = filterGroup.filter.querySelectorAll('input[type="date"]');
+        const values = this.query?.[filterGroup.name];
+        for (let i = 0; i < dateinputs.length; ++i) {
+          let input = dateinputs[i];
+          let type = input.getAttribute('data-type');
+          if (!isNullOrUndefined(values)) {
+            let value = values[type];
+            if (!isNullOrUndefined(value)) {
+              input.value = value;
+            }
+          }
+
+          input.addEventListener('change', this.#handleDateUpdate.bind(this));
+        }
+      } break;
+
+      case 'searchbar': {
+        const searchbar = filterGroup.filter.querySelector('#searchterm');
+        const value = this.query?.[filterGroup.name];
+        if (!isNullOrUndefined(value)) {
+          searchbar.value = value;
+        }
+
+        searchbar.addEventListener('keyup', this.#handleSearchbarUpdate.bind(this));
+      } break;
+
+      case 'pagination': {
+        const value = this.query?.[filterGroup.name];
+        if (!isNullOrUndefined(value)) {
+          filterGroup.filter.setAttribute('data-value', value);
+        }
+
+        const previous = filterGroup.filter.querySelector('a[data-value="previous"]');
+        previous.addEventListener('click', this.#handlePaginationUpdate.bind(this));
+
+        const next = filterGroup.filter.querySelector('a[data-value="next"]');
+        next.addEventListener('click', this.#handlePaginationUpdate.bind(this));
+      } break;
+
+      case 'option': {
+        const value = this.query?.[filterGroup.name];
+        if (!isNullOrUndefined(value)) {
+          for (let i = 0; i < filterGroup.filter.options.length; ++i) {
+            const option = filterGroup.filter.options[i];
+            option.selected = option.value == value;
+            option.dispatchEvent(new CustomEvent('change', { bubbles: true, detail: { filterSet: true } }));
+          }
+          filterGroup.filter.value = value;
+        }
+
+        filterGroup.filter.addEventListener('change', this.#handleOptionUpdate.bind(this));
+      } break;
+
+      default: break;
+    }
+  }
+
+  /**
+   * handleSelectedItem
+   * @desc handles the change event for selected items within selection view
+   * @param {event} e the assoc. event
+   */
+  #handleSelectedItem(e) {
+    const target = e.target;
+    const targetId = parseInt(target.getAttribute('data-id'));
+    const targetHistoryId = parseInt(target.getAttribute('data-history'));
+    const index = this.dialogue.data.findIndex(x => x?.id == targetId && x?.history_id == targetHistoryId);
+    if (isNullOrUndefined(index)) {
+      return;
+    }
+    
+    this.dialogue.data.splice(index, 1);
+    target.parentNode.remove();
+  }
+
+  /**
+   * handleChildSelection
+   * @desc handles the change event for child selector components
+   * @param {event} e the assoc. event
+   */
+  #handleChildSelection(e) {
+    const target = e.target;
+    const field = target.getAttribute('data-field');
+    const name = target.getAttribute('data-name');
+    const prefix = target.getAttribute('data-prefix');
+
+    let childId = target.getAttribute('data-id');
+    let childVersion = target.getAttribute('data-history');
+    if (isNullOrUndefined(field) || isNullOrUndefined(childId) || isNullOrUndefined(childVersion)) {
+      return;
+    }
+
+    childId = parseInt(childId);
+    childVersion = parseInt(childVersion);
+
+    if (target.checked) {
+      if (this.isSelected(childId, childVersion)) {
+        return;
+      }
+
+      const packet = {
+        id: childId,
+        name: name,
+        type: field,
+        history_id: childVersion,
+        prefix: prefix,
+      };
+      
+      if (this.options.allowMultiple) {
+        this.dialogue.data.push(packet);
+        return;
+      }
+
+      const checkboxes = this.dialogue.page.querySelectorAll('#child-selector > input[type="checkbox"]');
+      for (let i = 0; i < checkboxes.length; ++i) {
+        let checkbox = checkboxes[i];
+        if (checkbox.checked && checkbox.getAttribute('id') != target.getAttribute('id')) {
+          checkbox.checked = false;
+        }
+      }
+      this.dialogue.data[0] = packet;
+      return;
+    }
+    
+    if (!this.isSelected(childId, childVersion)) {
+      return;
+    }
+    
+    const index = this.dialogue.data.findIndex(item => item.id == childId && item.history_id == childVersion);
+    this.dialogue.data.splice(index, 1);
+  }
+
+  /**
+   * handleCheckboxUpdate
+   * @desc handles the change event when a checkbox component is modified
+   * @param {event} e the assoc. event
+   */
+  #handleCheckboxUpdate(e) {
+    const target = e.target;
+    const field = target.getAttribute('data-field');
+    const value = target.getAttribute('data-value');
+    if (isNullOrUndefined(field) || isNullOrUndefined(value)) {
+      return;
+    }
+
+    if (!this.query.hasOwnProperty(field)) {
+      this.query[field] = [];
+    }
+
+    const index = this.query[field].indexOf(value);
+    if (target.checked) {
+      if (index >= 0) {
+        return;
+      }
+
+      this.query[field].push(value);
+      this.#resetPage();
+      this.#tryGetSearchResults()
+        .then((results) => this.#paintSearchResults(results))
+        .catch(console.warn);
+
+      return;
+    }
+
+    if (index < 0) {
+      return;
+    }
+
+    this.query[field].splice(index, 1);
+    this.#resetPage();
+    this.#tryGetSearchResults()
+      .then((results) => this.#paintSearchResults(results))
+      .catch(console.warn);
+    
+    return;
+  }
+
+  /**
+   * handleDateUpdate
+   * @desc handles the change event when a input[type=date] component is modified
+   * @param {event} e the assoc. event
+   */
+  #handleDateUpdate(e) {
+    const target = e.target;
+    const field = target.getAttribute('data-field');
+    const type = target.getAttribute('data-type');
+    if (isNullOrUndefined(field) || isNullOrUndefined(type)) {
+      return;
+    }
+
+    if (!target.checkValidity()) {
+      return;
+    }
+
+    if (!this.query.hasOwnProperty(field)) {
+      this.query[field] = { start: null, end: null };
+    }
+    this.query[field][type] = moment(target.value, CSEL_BEHAVIOUR.ACCEPTABLE_DATE_FORMAT).format(CSEL_BEHAVIOUR.DATE_FORMAT);
+
+    let dates = Object.values(this.query[field])
+      .filter(x => !isNullOrUndefined(x))
+      .sort((a, b) => moment(a, CSEL_BEHAVIOUR.DATE_FORMAT).diff(moment(b, CSEL_BEHAVIOUR.DATE_FORMAT)));
+  
+    if (dates.length > 1) {
+      let [ startDate, endDate ] = dates;
+      this.query[field].start = startDate;
+      this.query[field].end = endDate;
+      this.#resetPage();
+    }
+
+    this.#tryGetSearchResults()
+      .then((results) => this.#paintSearchResults(results))
+      .catch(console.warn);
+  }
+
+  /**
+   * handlePaginationUpdate
+   * @desc click event that handles pagination events
+   * @param {event} e the assoc. event
+   */
+  #handlePaginationUpdate(e) {
+    e.preventDefault();
+
+    const target = e.target;
+    const field = target.getAttribute('data-field');
+    if (isNullOrUndefined(field)) {
+      return;
+    }
+    
+    let value = target.getAttribute('data-value');
+    if (isNullOrUndefined(value)) {
+      return;
+    }
+
+    if (value === CSEL_BEHAVIOUR.PAGINATION.NEXT || value === CSEL_BEHAVIOUR.PAGINATION.PREVIOUS) {
+      const offset = value === CSEL_BEHAVIOUR.PAGINATION.NEXT ? 1 : -1;
+      const current = this.query.hasOwnProperty(field) ? this.query[field] : 1;
+      value = current + offset;
+    }
+
+    value = parseInt(value);
+    if (isNaN(value)) {
+      return;
+    }
+
+    if (this.options?.scrollOnResultChange) {
+      const container = this.dialogue?.page.querySelector('#search-response-content');
+      if (container) {
+        container.scroll({ top: 0, behaviour: 'smooth' });
+      }
+    }
+
+    this.query[field] = value;
+    this.#tryGetSearchResults()
+      .then((results) => this.#paintSearchResults(results))
+      .catch(console.warn);
+  }
+
+  /**
+   * handleSearchbarUpdate
+   * @desc handles the key up event when a searchbar is modified
+   * @param {event} e the assoc. event
+   */
+  #handleSearchbarUpdate(e) {
+    const code = e.keyIdentifier || e.which || e.keyCode;
+    if (code != CSEL_BEHAVIOUR.KEY_CODES.ENTER) {
+      return;
+    }
+
+    const target = e.target;
+    const field = target.getAttribute('data-field');
+    const value = target.value;
+    if (isNullOrUndefined(field) || isNullOrUndefined(value)) {
+      return;
+    }
+
+    const current = this.query.hasOwnProperty(field) ? this.query[field] : '';
+    if (current === value) {
+      return;
+    }
+
+    this.query[field] = value;
+    this.#resetPage();
+    this.#tryGetSearchResults()
+      .then((results) => this.#paintSearchResults(results))
+      .catch(console.warn);
+  }
+
+  /**
+   * handleOptionUpdate
+   * @desc handles dropdown event fired by option filters e.g. order_by
+   * @param {event} e the assoc. event
+   */
+  #handleOptionUpdate(e) {
+    const field = e.target.getAttribute('data-field');
+    if (isNullOrUndefined(field) || isStringEmpty(field)) {
+      return;
+    }
+
+    if (!isNullOrUndefined(e.detail) && 'filterSet' in e.detail) {
+      return;
+    }
+
+    const filterItem = this.filters[field];
+    this.query[field] = filterItem.filter.value;
+    this.#resetPage();
+    this.#tryGetSearchResults()
+      .then((results) => this.#paintSearchResults(results))
+      .catch(console.warn);
+  }
+
+  /**
+   * handleCancel
+   * @desc handles the cancel/exit btn
+   * @param {event} e the assoc. event
+   */
+  #handleCancel(e) {
+    if (!this.isOpen()) {
+      return;
+    }
+
+    const event = new CustomEvent(
+      'selectionUpdate',
+      {
+        detail: {
+          type: CSEL_EVENTS.CANCELLED,
+        }
+      }
+    );
+    this.dialogue?.element.dispatchEvent(event);
+  }
+
+  /**
+   * handleConfirm
+   * @desc handles the confirmation btn
+   * @param {event} e the assoc. event
+   */
+  #handleConfirm(e) {
+    if (!this.isOpen()) {
+      return;
+    }
+
+    const data = this.dialogue?.data;
+    const event = new CustomEvent(
+      'selectionUpdate',
+      {
+        detail: {
+          data: this.dialogue?.data,
+          type: CSEL_EVENTS.CONFIRMED,
+        }
+      }
+    );
+    this.dialogue?.element.dispatchEvent(event);
+  }
+
+  /**
+   * changeTabView
+   * @desc handles the tab buttons
+   * @param {event} e the assoc. event
+   */
+  #changeTabView(e) {
+    const target = e.target;
+    const desired = target.getAttribute('id');
+    if (target.classList.contains('active')) {
+      return;
+    }
+
+    if (!desired || !CSEL_VIEWS.hasOwnProperty(desired)) {
+      return;
+    }
+
+    this.#renderView(CSEL_VIEWS[desired]);
+  }
+}

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
@@ -462,6 +462,12 @@ export class ConceptSelectionService {
     return this.dialogue;
   }
 
+  /**
+   * isSelected
+   * @param {number} childId 
+   * @param {number} childVersion 
+   * @returns {boolean} that reflects the selected state of a Concept
+   */
   isSelected(childId, childVersion) {
     if (isNullOrUndefined(this.dialogue?.data)) {
       return false;

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/conceptSelectionService.js
@@ -64,7 +64,7 @@ const CSEL_BEHAVIOUR = {
  *       and are appended automatically if not overriden.
  */
 const CSEL_OPTIONS = {
-  // Template
+  // Which template to query when retrieving accessible entities
   template: 1,
 
   // Allow more than a single Concept to be selected

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/filterService.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/services/filterService.js
@@ -285,6 +285,17 @@ class FilterService {
       .catch(error => console.error(error));
   }
 
+  /**
+   * resetPage
+   * @desc Force reset page on filter mutation
+   */
+  #resetPage() {
+    if (isNullOrUndefined(this.query.page)) {
+      return;
+    }
+    this.query.page = 1;
+  }
+
   /*************************************
    *                                   *
    *                Init               *
@@ -457,6 +468,7 @@ class FilterService {
 
     const filterItem = this.filters[field];
     this.query[field] = filterItem.filter.value;
+    this.#resetPage();
     this.#postQuery();
   }
 
@@ -475,6 +487,7 @@ class FilterService {
     }
 
     this.query[field] = [start.format(FILTER_DATEPICKER_FORMAT), end.format(FILTER_DATEPICKER_FORMAT)]
+    this.#resetPage();
     this.#postQuery();
   }
 
@@ -502,6 +515,7 @@ class FilterService {
       }
 
       this.query[field].push(value);
+      this.#resetPage();
       this.#postQuery();
       return;
     }
@@ -511,6 +525,7 @@ class FilterService {
     }
 
     this.query[field].splice(index, 1);
+    this.#resetPage();
     this.#postQuery();
     return;
   }
@@ -539,6 +554,7 @@ class FilterService {
     }
 
     this.query[field] = value;
+    this.#resetPage();
     this.#postQuery();
   }
 
@@ -570,6 +586,7 @@ class FilterService {
     }
 
     this.query[field] = value;
+    this.#resetPage();
     this.#postQuery();
   }
 

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/utils.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/utils.js
@@ -25,8 +25,8 @@ const deepCopy = (obj) => {
   * mergeObjects
   * @desc Merges two objects together where the first object takes precedence (i.e., it's not overriden)
   * @param {object} a An object to clone that takes precedence
-  * @param {object} b The object to clone
-  * @returns {object} The cloned object
+  * @param {object} b The object to clone and merge into the first object
+  * @returns {object} The merged object
   */
 const mergeObjects = (a, b) => {
   Object.keys(b).forEach(key => {
@@ -76,7 +76,7 @@ const getTransitionMethod = () => {
   */
 const createElement = (tag, attributes) => {
   let element = document.createElement(tag);
-  if (attributes != null) {
+  if (attributes !== null) {
     for (var name in attributes) {
       if (element[name] !== undefined) {
         element[name] = attributes[name];
@@ -94,7 +94,7 @@ const createElement = (tag, attributes) => {
   * @desc Checks whether an element is scrolled into view
   * @param {node} elem The element to examine
   * @param {number} offset An offset modifier (if required)
-  * @returns {boolean}
+  * @returns {boolean} that reflects the scroll view status of an element
   */
 const isScrolledIntoView = (elem, offset = 0) => {
   const rect = elem.getBoundingClientRect();
@@ -109,7 +109,7 @@ const isScrolledIntoView = (elem, offset = 0) => {
   * @desc A promise that resolves when an element is scrolled into view
   * @param {node} elem The element to examine
   * @param {number} offset An offset modifier (if required)
-  * @returns {promise}
+  * @returns {promise} a promise that resolves once the element scrolls into the view
   */
 const elementScrolledIntoView = (elem, offset = 0) => {
   return new Promise(resolve => {
@@ -127,7 +127,9 @@ const elementScrolledIntoView = (elem, offset = 0) => {
 /**
   * getCookie
   * @desc Gets the CSRF token
-  * @reference https://docs.djangoproject.com/en/4.1/howto/csrf/
+  *       Ref @ https://docs.djangoproject.com/en/4.1/howto/csrf/
+  * @param {string} name the name of the cookie
+  * @returns {*} the cookie's value
   */
 const getCookie = (name) => {
   let cookieValue = null;
@@ -296,8 +298,9 @@ const tryOpenFileDialogue = ({ allowMultiple = false, extensions = null, callbac
 }
 
 /**
- * Get a template from a string
- * https://stackoverflow.com/posts/41015840/revisions
+ * interpolateHTML
+ * @desc Get a template from a string
+ *       Ref @ https://stackoverflow.com/posts/41015840/revisions
  * @param  {str} str The string to interpolate
  * @param  {object} params The parameters
  * @return {str} The interpolated string
@@ -310,6 +313,7 @@ const interpolateHTML = (str, params) => {
 
 /**
  * parseHTMLFromString
+ * @desc given a string of HTML, will return a parsed DOM
  * @param {str} str The string to parse as DOM elem
  * @returns {DOM} the parsed html
  */
@@ -320,6 +324,7 @@ const parseHTMLFromString = (str) => {
 
 /**
  * countUnique
+ * @desc counts the unique elements in an array
  * @param {iterable} array counts the number of unique elements
  * @return {integer} number of unique elements
  */
@@ -423,7 +428,6 @@ const parseDOI = (value) => {
 
 /**
  * waitForElement
- *  
  * @desc waits for an element to exist based on selector parameter
  * @param {string} selector the string to match 
  * @returns {promise} promise that resolves with the given element

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/utils.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/redesign/utils.js
@@ -275,7 +275,7 @@ const redirectToTarget = (elem) => {
  *  console.log(files); --> [file_1, ..., file_n]
  * }});
  */
-const tryOpenFileDialogue = ({ allowMultiple = false, extensions = null, callback = null } = {}) => {
+const tryOpenFileDialogue = ({ allowMultiple = false, extensions = null, callback = null }) => {
   const input = document.createElement('input');
   input.type = 'file';
 

--- a/CodeListLibrary_project/cll/static/scss/components/_buttons.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_buttons.scss
@@ -253,14 +253,14 @@
     text-align: left;
   }
 
-  &.create-icon:after {
+  &.import-icon:after {
     content: '\f381';
     cursor: pointer;
     pointer-events: auto;
     position: absolute;
     right: 0;
     height: 100%;
-    top: 0.65rem;
+    top: 25%;
     aspect-ratio: 1 / 1;
     font-family: var(--icons-name);
     font-style: var(--icons-style);
@@ -268,14 +268,14 @@
     text-align: center;
   }
 
-  &.import-icon:after {
+  &.create-icon:after {
     content: '\f0cb';
     cursor: pointer;
     pointer-events: auto;
     position: absolute;
     right: 0;
     height: 100%;
-    top: 0.65rem;
+    top: 25%;
     aspect-ratio: 1 / 1;
     font-family: var(--icons-name);
     font-style: var(--icons-style);
@@ -290,7 +290,7 @@
     position: absolute;
     right: 0;
     height: 100%;
-    top: 0.65rem;
+    top: 25%;
     aspect-ratio: 1 / 1;
     font-family: var(--icons-name);
     font-style: var(--icons-style);
@@ -305,7 +305,7 @@
     position: absolute;
     right: 0;
     height: 100%;
-    top: 0.65rem;
+    top: 25%;
     aspect-ratio: 1 / 1;
     font-family: var(--icons-name);
     font-style: var(--icons-style);

--- a/CodeListLibrary_project/cll/static/scss/components/_cards.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_cards.scss
@@ -214,14 +214,16 @@
   padding: 0 0 1.5rem 0;
   margin: 0 0 1rem 0;
 
-  &:active {
-    /* Should we animate it? */
-    @include prefix(transform, scale(0.99), webkit moz o);
-  }
-
-  &:focus-visible {
-    outline: 1px solid black;
-    border-radius: 2pt;
+  &:not(.inactive) {
+    &:active {
+      /* Should we animate it? */
+      @include prefix(transform, scale(0.99), webkit moz o);
+    }
+  
+    &:focus-visible {
+      outline: 1px solid black;
+      border-radius: 2pt;
+    }
   }
 
   &__click {
@@ -297,6 +299,13 @@
           justify-content: flex-end;
         }
       }
+    }
+
+    &-datagroup {
+      @include flex-col();
+      flex-wrap: nowrap;
+      width: 100%;
+      gap: 0.25rem;
     }
   }
 }

--- a/CodeListLibrary_project/cll/static/scss/components/_filters.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_filters.scss
@@ -71,22 +71,24 @@
 /// Selection search filters
 ///   @desc used exclusively by selectionService.js
 .selection-filters {
-  @include flex-col();
   display: none;
-  flex-wrap: nowrap;
-  flex: 1 auto;
-  margin-right: 1rem;
-  min-width: 175px;
-  max-width: 200px;
 
   @include media(">desktop") {
+    @include flex-col();
     display: flex;
+    flex: 1 auto;
+    flex-wrap: nowrap;
+    margin-right: 1rem;
     min-width: 225px;
     max-width: 250px;
+    max-height: 100%;
   }
   
   &__header {
-    @include flex-col();
+    @include flex-row();
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    align-items: center;
 
     & > h3 {
       padding: 0;
@@ -95,6 +97,14 @@
       font-weight: bold;
       line-height: 1;
       color: col(text-darkest);
+    }
+
+    &-options {
+      @include flex-col();
+
+      &>button:not(.show) {
+        display: none;
+      }
     }
   }
 

--- a/CodeListLibrary_project/cll/static/scss/components/_filters.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_filters.scss
@@ -19,7 +19,7 @@
 }
 
 /// Search filters
-///   @desc Aside search bar
+///   @desc Aside search bar for the main search page
 .side-search-filters {
   @include flex-col();
   display: none;
@@ -54,6 +54,59 @@
     width: 100%;
     min-width: 175px;
   
+    @include media(">desktop") {
+      display: flex;
+      min-width: 225px;
+    }
+  }
+}
+
+/// Filter group
+///   @desc primarily used by selection service
+.filter-group {
+  flex-direction: column nowrap;
+  padding: 0.5rem 0;
+}
+
+/// Selection search filters
+///   @desc used exclusively by selectionService.js
+.selection-filters {
+  @include flex-col();
+  display: none;
+  flex-wrap: nowrap;
+  flex: 1 auto;
+  margin-right: 1rem;
+  min-width: 175px;
+  max-width: 200px;
+
+  @include media(">desktop") {
+    display: flex;
+    min-width: 225px;
+    max-width: 250px;
+  }
+  
+  &__header {
+    @include flex-col();
+
+    & > h3 {
+      padding: 0;
+      margin: 0;
+      font-size: 18px;
+      font-weight: bold;
+      line-height: 1;
+      color: col(text-darkest);
+    }
+  }
+
+  &__container {
+    @include flex-col();
+    flex-wrap: nowrap;
+    flex-grow: 1;
+    margin-top: 0.5rem;
+    max-height: 42.5vh;
+    min-width: 175px;
+    overflow-y: scroll;
+
     @include media(">desktop") {
       display: flex;
       min-width: 225px;

--- a/CodeListLibrary_project/cll/static/scss/components/_inputs.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_inputs.scss
@@ -246,6 +246,22 @@
   &__header-item {
     @include flex-col();
   }
+
+  &__none-available {
+    display: block;
+    padding: 1rem;
+    border-radius: 0.1rem;
+    background-color: col(accent-semi-transparent);
+    margin-bottom: 0.5rem;
+
+    &-message {
+      text-align: center;
+    }
+
+    &:not(.show) {
+      display: none;
+    }
+  }
 }
 
 .date-range-field {

--- a/CodeListLibrary_project/cll/static/scss/components/_inputs.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_inputs.scss
@@ -196,6 +196,10 @@
   font-family: inherit;
   margin: 1rem 0 0 0;
 
+  &.no-margin {
+    margin: 0;
+  }
+
   &.fill-width {
     width: 100%;
   }
@@ -246,12 +250,19 @@
 
 .date-range-field {
   display: flex;
+  flex-flow: row nowrap;
   padding: 0;
   margin: 0;
   border: 0;
   width: 100%;
 
+  &.wrapped {
+    flex-wrap: wrap;
+    max-width: 100%;
+  }
+
   &__label {
+    display: flex;
     margin-right: 0.5rem;
 
     &:last-of-type {
@@ -294,6 +305,10 @@
   &.min-size {
     max-width: fit-content;
     margin-right: 0.5rem;
+  }
+
+  &.ignore-overflow {
+    overflow: visible;
   }
 }
 
@@ -436,6 +451,17 @@
   border: 0;
   width: 100%;
   height: fit-content;
+
+  &.indented {
+    padding: 0 0 0 0.5rem;
+  }
+
+  &.scrollable {
+    max-height: 45vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    flex-wrap: nowrap;
+  }
 }
 
 .code-text-input {
@@ -449,10 +475,10 @@
     cursor: pointer;
     display: block;
     position: absolute;
-    right: 8px;
-    top: 12px;
-    width: 20px;
-    height: 20px;
+    right: 5px;
+    top: 20%;
+    height: 55%;
+    aspect-ratio: 1 / 1;
     background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23687FCB' viewBox='0 0 16 16'%3e%3cpath d='M0 14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2a2 2 0 0 0-2 2v12zm4.5-6.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5a.5.5 0 0 1 0-1z'/%3e%3c/svg%3e");
     background-size: 20px;
     background-repeat: no-repeat;

--- a/CodeListLibrary_project/cll/static/scss/components/_modals.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_modals.scss
@@ -3,6 +3,13 @@
 @import '../_media';
 @import '../_utils';
 
+/// modal-open
+///   @desc stops body from scrolling when modal open
+.modal-open {
+  overflow: hidden;
+  position: fixed;
+}
+
 /// Target modal
 ///   @desc CSS-driven modal, used in create.html of Concept Creation
 .target-modal {
@@ -28,11 +35,32 @@
     z-index: 99999;
   }
 
+  &-sm {
+    .target-modal__container {
+      top: 20%;
+      left: 37.5%;
+      width: 25%;
+    }
+  }
+
+  &-md {
+    .target-modal__container {
+      top: 20%;
+      left: 25%;
+      width: 50%;
+    }
+  }
+
+  &-lg {
+    .target-modal__container {
+      top: 10%;
+      left: 12.5%;
+      width: 75%;
+    }
+  }
+  
   &__container {
     position: fixed;
-    top: 20%;
-    left: 25%;
-    width: 50%;
     border: 1px solid col(accent-darkish);
     border-radius: 0.25rem;
     background: #fefefe;
@@ -77,7 +105,12 @@
   }
 
   &__body {
+    max-height: 90vh;
     padding: 1rem;
+
+    &.no-pad {
+      padding: 0;
+    }
   }
 
   &__footer {

--- a/CodeListLibrary_project/cll/static/scss/components/_pagination.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_pagination.scss
@@ -8,7 +8,12 @@
 .pagination-box {
   @include flex-row();
   margin: 1rem 0 0 0;
+  align-self: flex-end;
   justify-content: flex-end;
+
+  &.push-bottom {
+    margin-bottom: auto;
+  }
 }
 
 .pagination-container {

--- a/CodeListLibrary_project/cll/static/scss/components/_scrollbars.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_scrollbars.scss
@@ -6,6 +6,11 @@
 /// Slim scrollbar 
 ///   @desc used for table content
 .slim-scrollbar {
+  /* Firefox */
+  scrollbar-color: var(--slim-scrollbar-active-color) col(clear) !important;
+  scrollbar-width: thin !important;
+
+  /* Webkit */
   &::-webkit-scrollbar {
     width: var(--slim-scrollbar-width);
     height: var(--slim-scrollbar-width);
@@ -34,6 +39,11 @@
 /// Filter scrollbar
 ///   @desc vertical scrollbar used for filters on search pages
 .filter-scrollbar {
+  /* Firefox */
+  scrollbar-color: var(--slim-scrollbar-active-color) col(clear) !important;
+  scrollbar-width: thin !important;
+
+  /* Webkit */
   &::-webkit-scrollbar {
     width: 6px;
     height: 12px;

--- a/CodeListLibrary_project/cll/static/scss/components/_search.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_search.scss
@@ -70,6 +70,13 @@
   flex-wrap: nowrap;
   flex-grow: 1;
   margin: 2rem 0 0 0;
+  align-items: flex-start;
+
+  &.as-selection {
+    margin: 0;
+    min-height: 30vh;
+    max-height: 100%;
+  }
 }
 
 /// Search results
@@ -77,11 +84,12 @@
 .entity-search-results {
   @include flex-col();
   flex: 5 auto;
+  max-height: 100%;
 
   &__header {
     @include flex-row();
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     margin-bottom: 1rem;
 
     &-results {
@@ -109,5 +117,11 @@
   &__container {
     @include flex-col();
     flex-grow: 1;
+
+    &.scrollable {
+      flex-wrap: nowrap;
+      max-height: 40vh;
+      overflow-y: auto;
+    }
   }
 }

--- a/CodeListLibrary_project/cll/static/scss/components/_tabView.scss
+++ b/CodeListLibrary_project/cll/static/scss/components/_tabView.scss
@@ -1,0 +1,72 @@
+@import '../_methods';
+@import '../_variables';
+@import '../_media';
+@import '../_utils';
+
+.tab-view {
+  @include flex-col();
+  width: 100%;
+  padding: 0.5rem 0 0 0;
+
+  &__tabs {
+    @include flex-row();
+    justify-content: flex-start;
+    align-content: flex-end;
+    padding: 0 0 0 1rem;
+    width: 100%;
+    max-width: 100%;
+
+    &-z-buffer {
+      z-index: 9999999;
+    }
+  }
+
+  &__tab {
+    @include app-font-style();
+    cursor: pointer;
+    display: flex;
+    padding: 0.5rem 0.5rem 1rem 0.5rem;
+    border: 1px solid transparent;
+    border-bottom: 0;
+    outline: none;
+    background-color: col(bg);
+    font-weight: 600;
+
+    &:after {
+      content: '';
+      position: absolute;
+      left: 0.5rem;
+      bottom: 0.25rem;
+      width: 0.5rem;
+      height: 4px;
+      background: col(accent-washed);
+    }
+
+    &:hover {
+      &:after {
+        background: col(accent-primary);
+      }
+    }
+    
+    &.active {
+      border: 1px solid col(accent-washed);
+      border-bottom: 2px solid col(bg);
+      margin-bottom: -2px;
+
+      &:after {
+        background: col(accent-primary);
+      }
+    }
+  }
+  
+  &__content {
+    @include flex-col();
+    flex-wrap: nowrap;
+    box-sizing: border-box;
+    padding: 1rem 0.5rem;
+    width: 100%;
+    max-width: 100%;
+    height: fit-content;
+    border-top: 1px solid col(accent-washed);
+  }
+}

--- a/CodeListLibrary_project/cll/static/scss/main.scss
+++ b/CodeListLibrary_project/cll/static/scss/main.scss
@@ -17,6 +17,7 @@
 @import 'components/_accordians';
 @import 'components/_scrollbars';
 @import 'components/_search';
+@import 'components/_tabView';
 @import 'components/_filters';
 @import 'components/_pagination';
 @import 'components/_markdown';

--- a/CodeListLibrary_project/cll/static/scss/pages/create.scss
+++ b/CodeListLibrary_project/cll/static/scss/pages/create.scss
@@ -216,12 +216,22 @@
     @include flex-row();
     width: 100%;
     justify-content: space-between;
+    margin-bottom: 0.5rem;
+    gap: 1rem;
   }
 
   &__container {
     @include flex-col();
     width: fit-content;
     justify-content: center;
+
+    &.as-row {
+      @include flex-row();
+      gap: 0.5rem;
+      margin-left: auto;
+      height: fit-content;
+      align-self: center;
+    }
   }
 
   &__title {

--- a/CodeListLibrary_project/cll/templates/clinicalcode/generic_entity/creation/create.html
+++ b/CodeListLibrary_project/cll/templates/clinicalcode/generic_entity/creation/create.html
@@ -15,7 +15,6 @@
 <meta http-equiv="Expires" content="0" />
 {% endblock cache_tags %}
 
-
 {% block indexing_robots %}
   {% with stop_robot_indexing=True %}
     {{ block.super }}
@@ -23,27 +22,22 @@
 {% endblock indexing_robots %}
 
 {% block container %}
-  <!-- Vendor -->
   <link rel="stylesheet" type="text/css" href="{% static 'js/clinicalcode/redesign/vendor/tinymde/tiny-mde.min.css' %}" />
   <script src="{% static 'js/clinicalcode/redesign/vendor/simple-datatables/simple-datatables.min.js' %}"></script>
   <script src="{% static 'js/clinicalcode/redesign/vendor/tinymde/tiny-mde.min.js' %}"></script>
   <script src="{% static 'js/clinicalcode/redesign/vendor/moment.min.js' %}"></script>
 
-  <!-- Dependencies -->
   {% compress js file %}
   <script src="{% static 'js/clinicalcode/redesign/vendor/lightpick.js' %}"></script>
+  <script src="{% static 'js/clinicalcode/redesign/components/dropdown.js' %}"></script>
   <script type="module" src="{% static 'js/clinicalcode/redesign/components/tooltipFactory.js' %}"></script>
   <script type="module" src="{% static 'js/clinicalcode/redesign/forms/entityCreator.js' %}"></script>
   <script type="module" src="{% static 'js/clinicalcode/redesign/components/stepsWizard.js' %}"></script>
   <script type="module" src="{% static 'js/clinicalcode/redesign/components/toastNotification.js' %}"></script>
   {% endcompress %}
 
-
-
-  <!-- Page Stylesheets -->
   <link href="{% sass_src 'scss/pages/create.scss' %}" rel="stylesheet" type="text/css" />
 
-  <!-- Form -->
   <header class="main-header">
     <div class="main-header__inner-container">
       {% breadcrumbs useMap=False includeHome=True includeHeader=False %}
@@ -104,6 +98,13 @@
 
   <data data-owner="entity-creator" id="referral-links" name="links" type="text/json" referral-url="{% url 'search_phenotypes' %}"></data>
   <data data-owner="entity-creator" id="form-method" name="method" type="int">{{ form_method.value }}</data>
+  <data data-owner="entity-creator" id="historical-data" name="is_historical" type="int">
+    {% if is_historical %}
+      1
+    {% else %}
+      0
+    {% endif %}
+  </data>
   <data data-owner="entity-creator" id="metadata-data" name="metadata" type="text/json">{{ metadata|jsonify|safe }}</data>
   <data data-owner="entity-creator" id="template-data" name="template" type="text/json">{{ template|jsonify|safe }}</data>
   {% if entity is not None %}

--- a/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
+++ b/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
@@ -1,29 +1,28 @@
 {% load static %}
 {% load entity_renderer %}
 <section class="concepts-view" id="concepts-view" data-field="{{ component.field_name }}" data-class="clinical-concept">
-  <!-- Concepts -->
   <data type="value" for="{{ component.field_name }}">{% if component.value %}{{ component.value|jsonify|safe }}{% endif %}</data>
   <section class="concepts-view__header">
     <div class="concepts-view__container">
       <p class="concepts-view__title">Your Concepts {% if component.mandatory %}<span class="detailed-input-group__mandatory">*</span>{% endif %}</h3>
       <p class="concepts-view__description">The Concepts that relate to this Phenotype:</p>
     </div>
-    <div class="concepts-view__container">
-      <button class="secondary-btn text-accent-darkest bold icon import-icon secondary-accent" aria-label="Create new Concept" id="create-concept-btn">
-        Add Concept
+    <div class="concepts-view__container as-row">
+      <button class="secondary-btn text-accent-darkest bold icon create-icon secondary-accent" aria-label="Create new Concept" id="create-concept-btn">
+        New Concept
+      </button>
+      <button class="secondary-btn text-accent-darkest bold icon import-icon secondary-accent" aria-label="Import Concepts" id="import-concept-btn">
+        Import Concepts
       </button>
     </div>
   </section>
 
-  <!-- When no concepts are available -->
   <section class="concept-list__none-available" id="no-available-concepts">
     <p class="concept-list__none-available-message">You haven't added any concepts yet</p>
   </section>
   
   <section class="concept-list" id="concept-content-list">
 
-    <!-- Concept list items -->
-    
   </section>
 
   <template id="concept-item">
@@ -50,7 +49,7 @@
         <!-- Finalised concept content when not editing -->
         <section class="concept-group-content__container show" id="concept-information">
           <section class="concept-group-content__details">
-            <h4>Codelist</h4>
+            <h4>${subheader}</h4>
             <ul class="chips-group" id="coding-system-chip">
               <li class="chip bold washed-accent text-accent-darkest codelist-icon icon-accent-highlight">
                 <a id="coding-system-info" class="chip-text" data-coding-id="${coding_id}">${coding_system}</a>
@@ -71,9 +70,7 @@
   </template>
 
   <template id="concept-editor">
-    <!-- Editing concept content menu -->
     <section class="concept-group-content__container show" id="concept-editing">
-      <!-- Concept information -->
       <div class="detailed-input-group fill">
         <h3 class="detailed-input-group__title">Name</h3>
         <p class="detailed-input-group__description">The name of the Concept</p>
@@ -87,7 +84,6 @@
         </select>
       </div>
 
-      <!-- Inclusion Rulesets -->
       <section class="concept-group-content__details">
         <div class="concept-group-content__details-explanation">
           <h3>Inclusion Rules</h3>
@@ -103,6 +99,7 @@
               <ul class="dropdown-btn__menu fall-right">
                 <li aria-label="Add Searchterm Rule" role="button" tabindex="0" data-source="SEARCH_TERM">Add Searchterm</li>
                 <li aria-label="Add Import File Rule" role="button" tabindex="0" data-source="FILE_IMPORT">Import from File</li>
+                <li aria-label="Add Concept Import Rule" role="button" tabindex="0" data-source="CONCEPT_IMPORT">Import from Concept</li>
               </ul>
             </label>
           </fieldset>
@@ -118,7 +115,6 @@
         </section>
       </section>
 
-      <!-- Exclusion Rulesets -->
       <section class="concept-group-content__details">
         <div class="concept-group-content__details-explanation">
           <h3>Exclusion Rules</h3>
@@ -134,6 +130,7 @@
               <ul class="dropdown-btn__menu fall-right">
                 <li aria-label="Add Searchterm Rule" role="button" tabindex="0" data-source="SEARCH_TERM">Add Searchterm</li>
                 <li aria-label="Add Import File Rule" role="button" tabindex="0" data-source="FILE_IMPORT">Import from File</li>
+                <li aria-label="Add Concept Import Rule" role="button" tabindex="0" data-source="CONCEPT_IMPORT">Import from Concept</li>
               </ul>
             </label>
           </fieldset>
@@ -149,7 +146,6 @@
         </section>
       </section>
 
-      <!-- Codelist display -->
       <section class="concept-group-content__details">
         <div class="concept-group-content__details-explanation">
           <h3>Codelist</h3>
@@ -163,7 +159,6 @@
         
       </div>
 
-      <!-- Cancel / Confirm Concept changes -->
       <div class="concept-group-content__editor-buttons">
         <button class="secondary-btn text-accent-darkest bold washed-accent" aria-label="Cancel Changes" id="cancel-changes">Cancel</button>
         <button class="primary-btn text-accent-darkest bold secondary-accent" aria-label="Confirm Changes" id="confirm-changes">Confirm</button>
@@ -237,6 +232,40 @@
           <h3 class="detailed-input-group__title sm">File Import Rule</h3>
           <p class="detailed-input-group__description">This rule describes any codes retrieved from a file</p>
           <input class="text-input" aria-label="Imported File" type="text"
+              value="${source}" data-item="rule" disabled>
+        </div>
+      </article>
+    </div>
+  </template>
+
+  <template id="concept-rule">
+    <div class="fill-accordian" id="rule-item-${id}" data-index="${index}">
+      <input class="fill-accordian__input" id="rule-${id}" name="rule-${id}" type="checkbox" />
+      <label class="fill-accordian__label" id="rule-${id}" for="rule-${id}" role="button" tabindex="0">
+        <span>${name}</span>
+      </label>
+      <article class="fill-accordian__container">
+        <div class="detailed-input-group fill">
+          <div class="detailed-input-group__header">
+            <div class="detailed-input-group__header-item">
+              <h3 class="detailed-input-group__title sm">Rule Name</h3>
+              <p class="detailed-input-group__description">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+            </div>
+            <div class="detailed-input-group__header-item">
+              <span tooltip="Remove Ruleset" direction="left">
+                <button id="remove-rule-btn" class="publication-list-group__list-item-btn" data-target="${index}">
+                  <span class="delete-icon"></span>
+                  <span>Remove</span>
+                </button>
+              </span>
+            </div>
+          </div>
+          <input class="text-input" aria-label="Rule Name" type="text" id="rule-name" name="rule-name" placeholder="" minlength="3" pattern="^[a-zA-Z]{1,}.*?" value="${name}">
+        </div>
+        <div class="detailed-input-group fill">
+          <h3 class="detailed-input-group__title sm">Concept Import Rule</h3>
+          <p class="detailed-input-group__description">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          <input class="text-input" aria-label="Imported Concept" type="text"
               value="${source}" data-item="rule" disabled>
         </div>
       </article>

--- a/CodeListLibrary_project/cll/templates/components/search/results.html
+++ b/CodeListLibrary_project/cll/templates/components/search/results.html
@@ -5,7 +5,6 @@
     <p>{{ page_obj.start_index|stylise_number }}-{{ page_obj.end_index|stylise_number }} of over {{ page_obj.paginator.count|stylise_number }}</p>
   </div>
   <div class="entity-search-results__header-modifiers">
-    <!-- e.g. 'Order By', 'Results per Page' -->
     <div class="selection-group">
       <p class="selection-group__title">Order By:</p>
       <select id="order-by-filter" placeholder-text="By Relevance" data-element="dropdown" data-controller="filter" data-field="order_by" data-class="option">


### PR DESCRIPTION
# Issue
See:
- #1152 

# Concept Selection
> To use, import `ConceptSelectionService` from '_../services/conceptSelectionService.js_'

### Summary
Extensible and reusable class to prompt the selection of one or more Concepts from a list of accessible Phenotypes, where the user is either (a) the owner phenotype of a Concept is published or (b) the requesting user has access to the child Concepts via its permissions.

It is possible to reuse this service, and its associated methods, for the selection of Concepts for WorkingSet creation - the parameters below can be used to tweak its functionality to undertake this task.

### Optional parameters
| Name                   | Default             | Description                                                                                                         |
|------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------|
| `template`             | `1`                 | Which template to query when retrieving entities                                                                    |
| `allowMultiple`        | `true`              | Whether to allow more than a single Concept to be selected                                                          |
| `maintainSelection`    | `true`              | Whether to remember the selection when  previously opened (requires `allowMultiple` flag)                           |
| `scrollOnResultChange` | `true`              | Whether to scroll to the top of results during pagination                                                           |
| `promptTitle`          | `'Import Concepts'` | The title of the prompt                                                                                             |
| `promptConfirm`        | `'Confirm'`         | The confirm button inner text                                                                                       |
| `promptCancel`         | `'Cancel'`          | The cancel button inner text                                                                                        |
| `promptSize`           | `'lg'`              | An enum to determine the size of the prompt, sizes include: sm, md, lg                                              |
| `maintainFilters`      | `true`              | Whether to maintain applied filters when switching views                                                            |
| `ignoreFilters`        | `[]`                | A list of filters to ignore & hide from users (by field name, expects `str`)                                                          |
| `forceFilters`         | `{}`                | An object to force filter context, containing filters and the values to force on each query                         |
| `childFilters`         | `['coding_system']` | A list of filter names, if any, to apply to children. The applied value of these filters is given by `forceFilters` |
| `useCachedResults`     | `true`              | Whether to cache and used stored results for queries                                                                |

### Usage
e.g.
```js
// e.g. some initialisation data
const templateId = 1;
const codingSystem = {
  id: 4,
  name: 'ICD-10',
};

// Create a ConceptSelection prompt
const prompt = new ConceptSelectionService({
  template: templateId,
  promptTitle: `Import Concepts with ${codingSystem.name} codelists`,
  allowMultiple: false,
  ignoreFilters: ['coding_system'],
  forceFilters: {
    coding_system: codingSystem.id,
  },
});

// Show the prompt to the user and request a selection
prompt
  /* open the search prompt, starting with the `ConceptSelectionService.Views.Search` view */
  .show(ConceptSelectionService.Views.Search)
  /* when the user selects the 'Confirm' button... */
  .then((data) => {
    let conceptIds = data.map(item => item.id);
    let conceptVersionIds = data.map(item => item.history_id);
    
    // some fetch method to retrieve other related information, e.g. codelists
    // ...do stuff with the results

  })
  /* if an error occurs or if the user pressed the 'Cancel' button... */
  .catch((e) => {
    if (typeof e === 'undefined' || e === null) {
      console.error('Error occurred whilst fetching results:', e);
      return;
    }

    // ...otherwise, the user cancelled the prompt and did not import any concepts

  });

// Closing a prompt, if required, at some other point
// ...e.g. async close the prompt after 5 seconds
setTimeout(() => {
  prompt.close();
}, 5000);
```