### PR TITLE
init image uploading backend

### DIFF
--- a/CodeListLibrary_project/clinicalcode/admin.py
+++ b/CodeListLibrary_project/clinicalcode/admin.py
@@ -6,10 +6,10 @@ import datetime
 from .models import (Brand, CodingSystem, CodingSystemFilter, DataSource, Operator, Tag)
 from .models.EntityClass import EntityClass
 from .models.GenericEntity import GenericEntity
+from .models.GenericEntityImage import GenericEntityImage
 from .models.Template import Template
 from .forms.TemplateForm import TemplateAdminForm
 from .forms.EntityClassForm import EntityAdminForm
-
 
 @admin.register(CodingSystemFilter)
 class CodingSystemFilterAdmin(admin.ModelAdmin):
@@ -124,3 +124,7 @@ class EntityClassAdmin(admin.ModelAdmin):
         obj.modified_by = request.user
         obj.modified = timezone.now()
         obj.save()
+
+@admin.register(GenericEntityImage)
+class GenericEntityImageFilterAdmin(admin.ModelAdmin):
+    list_display = ['id', 'name']

--- a/CodeListLibrary_project/clinicalcode/entity_utils/constants.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/constants.py
@@ -224,6 +224,11 @@ API_MAP_FIELD_NAMES = {
 }
 
 '''
+    Max image size for uploading, 5MB
+'''
+MAX_IMAGE_SIZE = 5242880
+
+'''
     Describes fields that should be stripped from entity list api response
 '''
 ENTITY_LIST_API_HIDDEN_FIELDS = [

--- a/CodeListLibrary_project/clinicalcode/entity_utils/image_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/image_utils.py
@@ -1,0 +1,8 @@
+from PIL import Image
+import hashlib
+
+def get_hash(image):
+    '''
+
+    '''
+    return hashlib.md5(Image.open(image).tobytes()).hexdigest()

--- a/CodeListLibrary_project/clinicalcode/models/GenericEntityImage.py
+++ b/CodeListLibrary_project/clinicalcode/models/GenericEntityImage.py
@@ -1,0 +1,47 @@
+from django.core.exceptions import ValidationError
+from django.contrib.auth.models import User
+from django.db import models
+from PIL import Image
+
+from ..entity_utils import constants
+from ..entity_utils import image_utils
+
+def image_path(instance, filename):
+    '''
+        Will be uuid 
+    '''
+    return 'entity/%s_%s' % (instance.name, image_utils.get_hash(instance.image)) 
+
+def validate_image(image):
+    '''
+    
+    '''
+    if image.file.size > constants.MAX_IMAGE_SIZE:
+        raise ValidationError('Exceeds max image size: %s' % constants.MAX_IMAGE_SIZE)
+
+class GenericEntityImage(models.Model):
+    '''
+    
+    '''
+    id = models.AutoField(primary_key=True)
+
+    entity_owner = models.ForeignKey('clinicalcode.GenericEntity', on_delete=models.SET_NULL, null=True, blank=True, related_name='images')
+    name = models.CharField(max_length=250)
+    image = models.ImageField(upload_to=image_path, validators=[validate_image])
+
+    ''' Creation information '''
+    created = models.DateTimeField(auto_now_add=True)
+    created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name="uploaded_images")
+
+    is_deleted = models.BooleanField(null=True, default=False)
+    deleted = models.DateTimeField(null=True, blank=True)
+    deleted_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name="deleted_images")
+
+    def save(self, *args, **kwargs):
+        instance = super(GenericEntityImage, self).save(*args, **kwargs)
+        image = Image.open(instance.image.path)
+        image.save(instance.image.path, quality=constants.IMAGE_COMPRESSION_QUALITY, optimize=True)
+        return instance
+
+    def __str__(self):
+        return self.name

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -16,6 +16,7 @@ services:
       - ./env_vars.txt
     volumes:
       - ./cl_log/:/home/config_cll/cll_srvr_logs/
+      - ./media:/var/www/concept_lib_sites/v1/CodeListLibrary_project/media
     depends_on:
       - redis
 

--- a/docker/docker-compose.test.yaml
+++ b/docker/docker-compose.test.yaml
@@ -33,6 +33,8 @@ services:
     depends_on:
       - postgres
       - redis
+    volumes:
+      - ../CodeListLibrary_project/cll/media/:/var/www/concept_lib_sites/v1/CodeListLibrary_project/media
 
   redis:
     image: redis:7.0-bullseye

--- a/docker/production/cll.conf
+++ b/docker/production/cll.conf
@@ -18,6 +18,11 @@ WSGIScriptAlias     /           /var/www/concept_lib_sites/v1/CodeListLibrary_pr
     Require all granted
   </Directory>
 
+  <Directory /var/www/concept_lib_sites/v1/CodeListLibrary_project/media>
+    Require all granted
+    LimitRequestBody 10485760 
+  </Directory>
+
   <Directory /var/www/concept_lib_sites/v1/CodeListLibrary_project>
     <Files wsgi.py>
       Require all granted

--- a/docker/requirements/base.txt
+++ b/docker/requirements/base.txt
@@ -35,3 +35,4 @@ typing==3.7.4.3
 tzdata==2022.2
 urllib3==1.26.12
 wget==3.2
+Pillow==10.0.0


### PR DESCRIPTION
## Backend
 - [x] Apache config
 - [x] GenericEntityImage DB
 - [ ] Image upload/retrieval through phenotype/ endpoints
 - [ ] Image upload through phenotype builder backend
 - [ ] Image validation

## Frontend
- [ ] Rendering images on detail
- [ ] Modify simple markdown to include image uploading / selection
- [ ] Image upload in phentoype builder js
- [ ] Image validation
- [ ] Assoc. images viewable in profile