### PR TITLE
Create update and detail page link visibility fix for entity

### DIFF
--- a/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
@@ -894,7 +894,6 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
                 concept_data['phenotype_owner_history_id'] = entity_from_concept.values_list('history_id',flat=True)[index]
     
     # Set the requested entity id
-    
     concept_data['requested_entity_id'] = requested_entity_id
         
 

--- a/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
@@ -1,3 +1,4 @@
+
 from django.db import connection
 from django.db.models import ForeignKey
 from django.http.request import HttpRequest
@@ -745,7 +746,7 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
                               aggregate_component_codes=False, include_component_codes=True,
                               include_attributes=False, strippable_fields=None,
                               remove_userdata=False, hide_user_details=False,
-                              derive_access_from=None, format_for_api=False,
+                              derive_access_from=None,requested_entity_id=None, format_for_api=False,
                               include_source_data=False):
     """
       [!] Note: This method ignores permissions to derive data - it should only be called from a
@@ -878,7 +879,7 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
         concept_data['code_attribute_header'] = attribute_headers
     
     # Set phenotype owner
-    phenotype_owner = concept.phenotype_owner
+    phenotype_owner = concept.phenotype_owner   
     if phenotype_owner:
         concept_data['phenotype_owner'] = phenotype_owner.id
         entity_from_concept = GenericEntity.history.filter(
@@ -891,6 +892,10 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
             history_ids_concept = [j['concept_version_id'] for j in value['concept_information']]
             if concept_history_id in history_ids_concept:
                 concept_data['phenotype_owner_history_id'] = entity_from_concept.values_list('history_id',flat=True)[index]
+    
+    # Set the requested entity id
+    
+    concept_data['requested_entity_id'] = requested_entity_id
         
 
 

--- a/CodeListLibrary_project/clinicalcode/entity_utils/create_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/create_utils.py
@@ -81,6 +81,7 @@ def get_template_creation_data(request, entity, layout, field, default=None):
                 item['concept_id'],
                 item['concept_version_id'],
                 aggregate_component_codes=False,
+                requested_entity_id=entity.id,
                 derive_access_from=request,
                 include_source_data=True,
                 include_attributes=True

--- a/CodeListLibrary_project/clinicalcode/templatetags/detail_pg_renderer.py
+++ b/CodeListLibrary_project/clinicalcode/templatetags/detail_pg_renderer.py
@@ -244,7 +244,8 @@ def get_template_creation_data(entity, layout, field, request=None, default=None
                 remove_userdata=True,
                 hide_user_details=True,
                 include_component_codes=False, 
-                include_attributes=True, 
+                include_attributes=True,
+                requested_entity_id=entity.id, 
                 include_reviewed_codes=True,
                 derive_access_from=request
             )

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/forms/clinical/conceptCreator.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/forms/clinical/conceptCreator.js
@@ -1219,6 +1219,7 @@ export default class ConceptCreator {
       'concept_version_id': concept?.concept_version_id,
       'coding_id': concept?.coding_system?.id,
       'phenotype_owner': concept?.details?.phenotype_owner || '',
+      'requested_entity_id':concept?.details?.requested_entity_id || '',
       'phenotype_owner_history_id': concept?.details?.phenotype_owner_history_id || '',
       'phenotype_owner_version_url': phenotype_version_url,
       'coding_system': concept?.coding_system?.description,

--- a/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
+++ b/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
@@ -32,7 +32,7 @@
       <span class="concept-list__group-item" id="concept-accordian-header">
         <span class="contextual-icon" tabindex="0" aria-label="Expand Concept" role="button" data-target="is-open"></span>
         <span class="concept-name"  tabindex="0" aria-label="Expand Concept" role="button" data-target="is-open">
-          ${phenotype_owner ? `<a href="${phenotype_owner_version_url}" target="_blank">${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}</a>` : ``} ${coding_system ? ' | ' + coding_system : ''}${out_of_date ? ' | <strong>Legacy Version</strong>' : ''}
+          ${phenotype_owner !== requested_entity_id ? `<a href="${phenotype_owner_version_url}" target="_blank">${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}</a>` : phenotype_owner ? `${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}` : ''}${coding_system ? ' | ' + coding_system : ''}${out_of_date ? ' | <strong>Legacy Version</strong>' : ''}
         </span>
         <span class="concept-buttons">
           ${can_edit

--- a/CodeListLibrary_project/cll/templates/components/details/outputs/phenotype_clinical_code_lists.html
+++ b/CodeListLibrary_project/cll/templates/components/details/outputs/phenotype_clinical_code_lists.html
@@ -62,8 +62,13 @@
         <label class="fill-accordian__label" id="concept-{{ c.concept_id }}-{{ c.concept_version_id }}"
             for="concept-{{ c.concept_id }}-{{ c.concept_version_id }}" role="button" tabindex="0">
           <span>
+            {% if c.details.phenotype_owner == c.details.requested_entity_id %}
+              {{c.details.phenotype_owner}} / {{c.details.phenotype_owner_history_id}} / C{{ c.concept_id }}
+            {% else %}
+            {% if c.details.phenotype_owner %}
             <a href="{% url 'entity_history_detail' pk=c.details.phenotype_owner history_id=c.details.phenotype_owner_history_id %}">{{c.details.phenotype_owner}} / {{c.details.phenotype_owner_history_id}} / C{{ c.concept_id }}</a>
-           
+            {% endif %}
+            {% endif %}
             &nbsp;-&nbsp;{{ c.details.name }}
             &nbsp;|&nbsp;<em>{{ c.coding_system.name }}</em>
 


### PR DESCRIPTION
There is a bug when we want  to see the entity link but sometimes there is problem if entity has the same entity version . So we want to preserve and see the link only if entity concept is not realated to the same entity 