### PR TITLE
fix: concept linkage & concept name rendering

### DIFF
--- a/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
@@ -885,7 +885,8 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
 
         latest_version_id = permission_utils.get_latest_owner_version_from_concept(
             phenotype_id=phenotype_owner.id,
-            concept_id=concept.id
+            concept_id=historical_concept.id,
+            concept_version_id=historical_concept.history_id
         )
 
         if latest_version_id is not None:

--- a/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
@@ -885,8 +885,7 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
 
         latest_version_id = permission_utils.get_latest_owner_version_from_concept(
             phenotype_id=phenotype_owner.id,
-            concept_id=concept.id,
-            concept_version_id=historical_concept.history_id
+            concept_id=concept.id
         )
 
         if latest_version_id is not None:

--- a/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/concept_utils.py
@@ -746,8 +746,8 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
                               aggregate_component_codes=False, include_component_codes=True,
                               include_attributes=False, strippable_fields=None,
                               remove_userdata=False, hide_user_details=False,
-                              derive_access_from=None,requested_entity_id=None, format_for_api=False,
-                              include_source_data=False):
+                              derive_access_from=None, requested_entity_id=None,
+                              format_for_api=False, include_source_data=False):
     """
       [!] Note: This method ignores permissions to derive data - it should only be called from a
                 a method that has previously considered accessibility
@@ -882,21 +882,18 @@ def get_clinical_concept_data(concept_id, concept_history_id, include_reviewed_c
     phenotype_owner = concept.phenotype_owner   
     if phenotype_owner:
         concept_data['phenotype_owner'] = phenotype_owner.id
-        entity_from_concept = GenericEntity.history.filter(
-                    id=phenotype_owner.id
-                )
-        template_data = entity_from_concept.values_list('template_data',flat=True)
 
-        #Iterate through the concept_information to find the phenotype owner history
-        for index, value in enumerate(template_data):
-            history_ids_concept = [j['concept_version_id'] for j in value['concept_information']]
-            if concept_history_id in history_ids_concept:
-                concept_data['phenotype_owner_history_id'] = entity_from_concept.values_list('history_id',flat=True)[index]
+        latest_version_id = permission_utils.get_latest_owner_version_from_concept(
+            phenotype_id=phenotype_owner.id,
+            concept_id=concept.id,
+            concept_version_id=historical_concept.history_id
+        )
+
+        if latest_version_id is not None:
+            concept_data['phenotype_owner_history_id'] = latest_version_id
     
     # Set the requested entity id
     concept_data['requested_entity_id'] = requested_entity_id
-        
-
 
     # Set base
     if not format_for_api:

--- a/CodeListLibrary_project/clinicalcode/entity_utils/permission_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/permission_utils.py
@@ -264,7 +264,7 @@ def get_accessible_entities(
 
     return entities.distinct('id')
 
-def get_latest_owner_version_from_concept(phenotype_id, concept_id, concept_version_id, default=None):
+def get_latest_owner_version_from_concept(phenotype_id, concept_id, concept_version_id=None, default=None):
     """
         Gets the latest phenotype owner version id from a given concept
         and its expected owner id
@@ -274,7 +274,7 @@ def get_latest_owner_version_from_concept(phenotype_id, concept_id, concept_vers
 
             concept_id (int): The child concept id
 
-            concept_version_id (int): The child concept version id
+            concept_version_id (int): An optional child concept version id
 
             default (any): An optional default return value
 
@@ -284,7 +284,11 @@ def get_latest_owner_version_from_concept(phenotype_id, concept_id, concept_vers
     """
     latest_version = default
     with connection.cursor() as cursor:
-        sql = '''
+        version_id_clause = ''
+        if isinstance(concept_version_id, int):
+            version_id_clause = '''and (concepts->>'concept_version_id')::int = %(concept_version_id)s'''
+
+        sql = f'''
 
         with
           phenotype_children as (
@@ -302,7 +306,7 @@ def get_latest_owner_version_from_concept(phenotype_id, concept_id, concept_vers
                    and id = %(phenotype_id)s
               ) hge_concepts
              where (concepts->>'concept_id')::int = %(concept_id)s
-               and (concepts->>'concept_version_id')::int = %(concept_version_id)s
+               {version_id_clause}
           )
 
         select phenotype_id,

--- a/CodeListLibrary_project/clinicalcode/entity_utils/permission_utils.py
+++ b/CodeListLibrary_project/clinicalcode/entity_utils/permission_utils.py
@@ -264,6 +264,72 @@ def get_accessible_entities(
 
     return entities.distinct('id')
 
+def get_latest_owner_version_from_concept(phenotype_id, concept_id, concept_version_id, default=None):
+    """
+        Gets the latest phenotype owner version id from a given concept
+        and its expected owner id
+
+        Args:
+            phenotype_id (int): The phenotype owner id
+
+            concept_id (int): The child concept id
+
+            concept_version_id (int): The child concept version id
+
+            default (any): An optional default return value
+
+        Returns:
+            Returns either (a) an integer representing the version id
+                       OR; (b) the optional default value
+    """
+    latest_version = default
+    with connection.cursor() as cursor:
+        sql = '''
+
+        with
+          phenotype_children as (
+            select id as phenotype_id,
+                   history_id as phenotype_version_id,
+                   cast(concepts->>'concept_id' as integer) as concept_id,
+                   cast(concepts->>'concept_version_id' as integer) as concept_version_id
+              from (
+                select id,
+                       history_id,
+                       concepts
+                  from public.clinicalcode_historicalgenericentity as entity,
+                       json_array_elements(entity.template_data::json->'concept_information') as concepts
+                 where json_array_length(entity.template_data::json->'concept_information') > 0
+                   and id = %(phenotype_id)s
+              ) hge_concepts
+             where (concepts->>'concept_id')::int = %(concept_id)s
+               and (concepts->>'concept_version_id')::int = %(concept_version_id)s
+          )
+
+        select phenotype_id,
+               max(phenotype_version_id) as phenotype_version_id
+          from phenotype_children as pheno
+          join public.clinicalcode_historicalgenericentity as entity
+            on pheno.phenotype_id = entity.id
+            and pheno.phenotype_version_id = entity.history_id
+         group by phenotype_id;
+
+        '''
+
+        cursor.execute(
+            sql,
+            params={ 'phenotype_id': phenotype_id, 'concept_id': concept_id, 'concept_version_id': concept_version_id }
+        )
+
+        columns = [col[0] for col in cursor.description]
+        row = cursor.fetchone()
+
+        if row is not None:
+            row = dict(zip(columns, row))
+            latest_version = row.get('phenotype_version_id')
+
+    return latest_version
+        
+
 def get_accessible_concepts(
     request,
     group_permissions=[GROUP_PERMISSIONS.VIEW, GROUP_PERMISSIONS.EDIT]

--- a/CodeListLibrary_project/clinicalcode/urls.py
+++ b/CodeListLibrary_project/clinicalcode/urls.py
@@ -119,5 +119,6 @@ if not settings.CLL_READ_ONLY:
         #url(r'^adminTemp/admin_fix_malformed_codes/$', adminTemp.admin_fix_malformed_codes, name='admin_fix_malformed_codes'),
         url(r'^adminTemp/admin_force_adp_links/$', adminTemp.admin_force_adp_linkage, name='admin_force_adp_links'),
         url(r'^adminTemp/admin_fix_coding_system_linkage/$', adminTemp.admin_fix_coding_system_linkage, name='admin_fix_coding_system_linkage'),
+        url(r'^adminTemp/admin_fix_concept_linkage/$', adminTemp.admin_fix_concept_linkage, name='admin_fix_concept_linkage'),
         url(r'^adminTemp/admin_force_brand_links/$', adminTemp.admin_force_brand_links, name='admin_force_brand_links'),
     ]

--- a/CodeListLibrary_project/cll/static/js/clinicalcode/forms/clinical/conceptCreator.js
+++ b/CodeListLibrary_project/cll/static/js/clinicalcode/forms/clinical/conceptCreator.js
@@ -1212,20 +1212,24 @@ export default class ConceptCreator {
     const template = this.templates['concept-item'];
     const access = this.#deriveEditAccess(concept);
     const phenotype_version_url = `${window.location.origin}/phenotypes/${concept.details.phenotype_owner}/version/${concept.details.phenotype_owner_history_id}/detail`;
+  
+    const isImportedItem = concept?.details?.phenotype_owner && !!concept?.details?.requested_entity_id && concept?.details?.phenotype_owner !== concept?.details?.requested_entity_id;
     const html = interpolateString(template, {
       'subheader': access ? 'Codelist' : 'Imported Codelist',
       'concept_name': access ? concept?.details?.name : this.#getImportedName(concept),
       'concept_id': concept?.concept_id,
       'concept_version_id': concept?.concept_version_id,
       'coding_id': concept?.coding_system?.id,
-      'phenotype_owner': concept?.details?.phenotype_owner || '',
-      'requested_entity_id':concept?.details?.requested_entity_id || '',
+      'is_imported_item': isImportedItem,
+      'phenotype_owner': concept?.details?.phenotype_owner,
+      'requested_entity_id': concept?.details?.requested_entity_id,
       'phenotype_owner_history_id': concept?.details?.phenotype_owner_history_id || '',
       'phenotype_owner_version_url': phenotype_version_url,
       'coding_system': concept?.coding_system?.description,
       'out_of_date': !access ? concept?.details?.latest_version?.is_out_of_date : false,
       'can_edit': access,
     });
+
     const containerList = this.element.querySelector('#concept-content-list');
     const doc = parseHTMLFromString(html);
     const conceptItem = containerList.appendChild(doc.body.children[0]);

--- a/CodeListLibrary_project/cll/static/scss/_utils.scss
+++ b/CodeListLibrary_project/cll/static/scss/_utils.scss
@@ -112,3 +112,18 @@
     background-size: 100% 1px, auto;
   }
 }
+
+/// Mixin to apply wordwrap/break
+@mixin wrap-words() {
+  white-space: pre-wrap; /* CSS3 */    
+  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+  white-space: -pre-wrap; /* Opera 4-6 */    
+  white-space: -o-pre-wrap; /* Opera 7 */    
+  word-wrap: break-word; /* Internet Explorer 5.5+ */
+
+  word-break: break-word;
+  -ms-word-break: break-all; /* Legacy IE support */
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
+}

--- a/CodeListLibrary_project/cll/static/scss/pages/create.scss
+++ b/CodeListLibrary_project/cll/static/scss/pages/create.scss
@@ -352,14 +352,19 @@
         content: '\f1f8';
         color: col(accent-danger);
       }
-    
+
       .concept-name {
+        @include wrap-words();
         cursor: pointer;
         pointer-events: auto;
         font-weight: normal;
-        white-space: break-spaces;
         text-overflow: ellipsis;
         overflow: hidden;
+        max-width: 80%;
+
+        a {
+          @include wrap-words();
+        }
       }
     
       .concept-buttons {

--- a/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
+++ b/CodeListLibrary_project/cll/templates/components/create/inputs/clinical/concept.html
@@ -32,7 +32,11 @@
       <span class="concept-list__group-item" id="concept-accordian-header">
         <span class="contextual-icon" tabindex="0" aria-label="Expand Concept" role="button" data-target="is-open"></span>
         <span class="concept-name"  tabindex="0" aria-label="Expand Concept" role="button" data-target="is-open">
-          ${phenotype_owner !== requested_entity_id ? `<a href="${phenotype_owner_version_url}" target="_blank">${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}</a>` : phenotype_owner ? `${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}` : ''}${coding_system ? ' | ' + coding_system : ''}${out_of_date ? ' | <strong>Legacy Version</strong>' : ''}        
+          ${is_imported_item
+            ? `<a href="${phenotype_owner_version_url}" target="_blank">${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}</a>`
+            : (phenotype_owner ? `${phenotype_owner} / ${phenotype_owner_history_id} / ${concept_name}` : (concept_name || '')) }
+
+          ${coding_system ? ' | ' + coding_system : ''}${out_of_date ? ' | <strong>Legacy Version</strong>' : ''}
         </span>
         <span class="concept-buttons">
           ${can_edit

--- a/CodeListLibrary_project/cll/templates/components/details/outputs/phenotype_clinical_code_lists.html
+++ b/CodeListLibrary_project/cll/templates/components/details/outputs/phenotype_clinical_code_lists.html
@@ -61,8 +61,12 @@
             {% if c.details.phenotype_owner == c.details.requested_entity_id %}
               {{c.details.phenotype_owner}} / {{c.details.phenotype_owner_history_id}} / C{{ c.concept_id }}
             {% else %}
-              {% if c.details.phenotype_owner %}
+              {% if c.details.phenotype_owner and c.details.phenotype_owner_history_id %}
                 <a href="{% url 'entity_history_detail' pk=c.details.phenotype_owner history_id=c.details.phenotype_owner_history_id %}">{{c.details.phenotype_owner}} / {{c.details.phenotype_owner_history_id}} / C{{ c.concept_id }}</a>
+              {% elif c.details.phenotype_owner %}
+                <a href="{% url 'entity_detail' pk=c.details.phenotype_owner %}">{{c.details.phenotype_owner}} / C{{ c.concept_id }}</a>
+              {% else %}
+                C{{ c.concept_id }}
               {% endif %}
             {% endif %}
 

--- a/docs/sql-scripts/examine_concepts.sql
+++ b/docs/sql-scripts/examine_concepts.sql
@@ -208,3 +208,234 @@ select *
  limit 1;
 
 -------------------------------------------------------------
+
+-- Count concepts that have never had a phenotype_owner
+select count(*)
+  from public.clinicalcode_historicalconcept as hc
+  left join public.clinicalcode_historicalconcept as hci
+    on hc.id = hci.id and hc.history_id = hci.history_id
+ where hci.id is null;
+
+
+-- Show unlinked historical concept(s)
+with
+  /* Show total unlinked, incl. all versions */
+  total_counts as (
+    select
+      (
+        select count(*)
+          from public.clinicalcode_historicalconcept
+         where is_deleted is null or is_deleted = false
+      ) as total_concepts,
+      (
+        select count(*)
+          from public.clinicalcode_historicalconcept
+         where phenotype_owner_id is null and (is_deleted is null or is_deleted = false)
+      ) as unlinked_concepts
+  ),
+  /* Show counts by each entity (id) */
+  entity_counts as (
+    select
+      (
+        select count(*)
+          from (
+            select id
+              from public.clinicalcode_historicalconcept
+             where is_deleted is null or is_deleted = false
+             group by id
+          ) hci
+      ) as total_concepts,
+      (
+        select count(*)
+          from (
+            select id, phenotype_owner_id
+              from public.clinicalcode_historicalconcept
+             where phenotype_owner_id is null and (is_deleted is null or is_deleted = false)
+             group by id, phenotype_owner_id
+          ) hcid
+      ) as unlinked_concepts
+  )
+
+select total_concepts,
+       total_concepts - unlinked_concepts as linked_concepts,
+       unlinked_concepts
+  from entity_counts;
+
+
+-- Find phenotypes that incl. historical concepts that don't have a phenotype_owner
+select entity.phenotype_id,
+       entity.phenotype_version_id,
+       entity.concept_id,
+       entity.concept_version_id
+  from (
+    select id as phenotype_id,
+           history_id as phenotype_version_id,
+           cast(concepts->>'concept_id' as integer) as concept_id,
+           cast(concepts->>'concept_version_id' as integer) as concept_version_id
+      from (
+        select id,
+               history_id,
+               concepts
+          from public.clinicalcode_historicalgenericentity as entity,
+               json_array_elements(entity.template_data::json->'concept_information') as concepts
+         where template_id = 1
+           and json_array_length(entity.template_data::json->'concept_information') > 0
+      ) results
+  ) as entity
+  left join public.clinicalcode_historicalconcept as concept
+    on (
+      entity.concept_id = concept.id
+      and entity.concept_version_id = concept.history_id
+    )
+ where concept.phenotype_owner_id is null
+
+
+-- Find possible links
+with 
+  unlinked_concepts as (
+    select *
+      from public.clinicalcode_historicalconcept
+     where phenotype_owner_id is null
+  ),
+  entity_children as (
+    select id as phenotype_id,
+           history_id as phenotype_version_id,
+           cast(concepts->>'concept_id' as integer) as concept_id,
+           cast(concepts->>'concept_version_id' as integer) as concept_version_id
+      from (
+        select id,
+               history_id,
+               concepts
+          from public.clinicalcode_historicalgenericentity as entity,
+               json_array_elements(entity.template_data::json->'concept_information') as concepts
+         where template_id = 1
+           and json_array_length(entity.template_data::json->'concept_information') > 0
+      ) hge_concepts
+  )
+
+select cast(regexp_replace(entity.phenotype_id, '[a-zA-Z]+', '') as integer) as true_id,
+       entity.phenotype_id,
+       entity.phenotype_version_id,
+       entity.concept_id,
+       entity.concept_version_id
+  from unlinked_concepts as concept
+  join entity_children as entity
+    on entity.concept_id = concept.id and entity.concept_version_id = concept.history_id
+  order by true_id, entity.concept_id
+
+
+-- Update all historical records of a concept, such that:
+-- 
+--    it's phenotype_owner_id reflects the phenotype_id
+--    in which it was first present
+-- 
+
+/* Update from legacy reference first ... */
+with
+  legacy_reference as (
+    select phenotype.id as phenotype_id,
+           concept->>'concept_id' as concept_id,
+           concept->>'concept_version_id' as concept_version_id,
+           created
+      from public.clinicalcode_phenotype as phenotype,
+           json_array_elements(phenotype.concept_informations::json) as concept
+  ),
+  ranked_legacy_concepts as (
+    select phenotype_id,
+           cast(concept_id as integer) as concept_id,
+           cast(concept_version_id as integer) as concept_version_id,
+           rank() over (
+             partition by phenotype_id
+                 order by created asc
+           ) as ranking
+      from legacy_reference
+  )
+
+update public.clinicalcode_historicalconcept as trg
+   set phenotype_owner_id = src.phenotype_id
+  from (
+    select *
+      from ranked_legacy_concepts
+     where ranking = 1
+  ) as src
+ where trg.id = src.concept_id
+   and trg.phenotype_owner_id is null;
+
+/* ... then update from current reference */
+with
+  entity_reference as (
+    select id as phenotype_id,
+           history_id as phenotype_version_id,
+           cast(concepts->>'concept_id' as integer) as concept_id,
+           cast(concepts->>'concept_version_id' as integer) as concept_version_id
+      from (
+        select id,
+               history_id,
+               concepts
+          from public.clinicalcode_historicalgenericentity as entity,
+               json_array_elements(entity.template_data::json->'concept_information') as concepts
+         where template_id = 1
+           and json_array_length(entity.template_data::json->'concept_information') > 0
+      ) hge_concepts
+  ),
+  first_child_concept as (
+    select concept_id as concept_id,
+           min(concept_version_id) as concept_version_id
+      from entity_reference as entity
+     group by concept_id
+  ),
+  earliest_entity as (
+    select phenotype_id,
+           concept_id,
+           concept_version_id
+      from (
+        select phenotype_id,
+              rank() over (
+                partition by phenotype_id
+                    order by phenotype_version_id asc
+              ) as ranking,
+              concept.concept_id,
+              concept.concept_version_id
+          from entity_reference as entity
+          join first_child_concept as concept
+            using (concept_id, concept_version_id)
+      ) as hci
+     where ranking = 1
+  )
+
+update public.clinicalcode_historicalconcept as trg
+   set phenotype_owner_id = src.phenotype_id
+  from earliest_entity as src
+ where trg.id = src.concept_id
+   and trg.phenotype_owner_id is null;
+
+
+-------------------------------------------------------------
+
+-- get latest version of the phenotype owner from a concept
+
+with
+  phenotype_children as (
+    select id as phenotype_id,
+           history_id as phenotype_version_id,
+           cast(concepts->>'concept_id' as integer) as concept_id,
+           cast(concepts->>'concept_version_id' as integer) as concept_version_id
+      from (
+        select id,
+               history_id,
+               concepts
+          from public.clinicalcode_historicalgenericentity as entity,
+               json_array_elements(entity.template_data::json->'concept_information') as concepts
+         where json_array_length(entity.template_data::json->'concept_information') > 0
+           and id = %(phenotype_id)s
+      ) hge_concepts
+     where concept_id = %(concept_id)s
+  )
+
+select phenotype_id,
+       max(phenotype_version_id) as phenotype_version_id
+  from phenotype_children as pheno
+  join public.clinicalcode_historicalgenericentity as entity
+    on pheno.phenotype_id = entity.id
+    and pheno.phenotype_version_id = entity.history_id
+ group by phenotype_id;


### PR DESCRIPTION
# Issue

- Bug when rendering names due to loss of `version_id` field for `Model<Phenotype>` derived from `Model<Concept>`
- Reimplements migratory methods for `Model<Concept>` ownership
